### PR TITLE
Fix bug

### DIFF
--- a/Windows/bios_install_prep.ps1
+++ b/Windows/bios_install_prep.ps1
@@ -1,6 +1,10 @@
 # Run this to remove the rEFInd EFI entry as boot next EFI entry (bootsequence first)
 # Be sure to also disable the scheduled task enabling rEFInd as first in the bootsequence
 
-$REFIND_IDENT = bcdedit /enum FIRMWARE |findstr "den des"|Select-String rEFInd -Context 1,0|findstr "den"
-$REFIND_GUID = ($REFIND_IDENT -split ' ')[-1]
+$BCD_INFO = $(bcdedit /enum FIRMWARE)
+$FILE_IDX = ($BCD_INFO | Select-String 'refind_x64.efi').LineNumber
+$SEPARATORS = ($BCD_INFO | Select-String '--' ).LineNumber
+foreach ($_ in $SEPARATORS) { if ($_ -lt $FILE_IDX) { $GUID_IDX = $_ } }
+$REFIND_GUID = ($BCD_INFO | Select-Object -Index $GUID_IDX | Select-String "{.*}").Matches.Value
+
 bcdedit /set "{fwbootmgr}" bootsequence "$REFIND_GUID" /remove

--- a/Windows/bootsequence-rEFInd-first.ps1
+++ b/Windows/bootsequence-rEFInd-first.ps1
@@ -1,6 +1,10 @@
 # Setting next boot as rEFInd... Windows PowerShell script for task scheduler
 # Credit goes to Reddit user lucidludic for the idea and some code snippets (modified)
 
-$REFIND_IDENT = bcdedit /enum FIRMWARE |findstr "den des"|Select-String rEFInd -Context 1,0|findstr "den"
-$REFIND_GUID = ($REFIND_IDENT -split ' ')[-1]
+$BCD_INFO = $(bcdedit /enum FIRMWARE)
+$FILE_IDX = ($BCD_INFO | Select-String 'refind_x64.efi').LineNumber
+$SEPARATORS = ($BCD_INFO | Select-String '--' ).LineNumber
+foreach ($_ in $SEPARATORS) { if ($_ -lt $FILE_IDX) { $GUID_IDX = $_ } }
+$REFIND_GUID = ($BCD_INFO | Select-Object -Index $GUID_IDX | Select-String "{.*}").Matches.Value
+
 bcdedit /set "{fwbootmgr}" bootsequence "$REFIND_GUID" /addfirst


### PR DESCRIPTION
On Non-English devices, results of bcdedit.exe will be output in a variety of languages, resulting $REFIND_GUID inaccessible.This should fix it. 