### PR TITLE
Windows Powershell script to randomize PNG background images for rEFInd

### DIFF
--- a/Windows/rEFInd Background Randomizer/refind_bg_randomizer.ps1
+++ b/Windows/rEFInd Background Randomizer/refind_bg_randomizer.ps1
@@ -6,7 +6,7 @@ https://github.com/ryanrudolfoba/
 Prerequisites:
 
 Place png images that you wish to use as backgrounds for rEFInd here -
-C:\refind\backgrounds
+C:\refind_scripts\backgrounds
 
 Place this script in a scheduled task to automatically run at startup.
 
@@ -16,7 +16,7 @@ Clear-Host
 
 # set variables for ESP and random background
 Set-Variable -Name "ESP" -value (Compare-Object -PassThru (Get-PsDrive [A-Z]).Name ([char[]] 'DEFGHIJKLMNOPQRSTUVWXYZ') | Select-Object -first 1)
-Set-Variable -Name "RandomBackground" -value (Get-ChildItem -Path "c:\refind\backgrounds\*.png" | Get-Random -count 1)
+Set-Variable -Name "RandomBackground" -value (Get-ChildItem -Path "c:\refind_scripts\backgrounds\*.png" | Get-Random -count 1)
 
 # mount ESP partition to the next available drive letter
 mountvol $ESP`: /s

--- a/Windows/rEFInd Background Randomizer/refind_bg_randomizer.ps1
+++ b/Windows/rEFInd Background Randomizer/refind_bg_randomizer.ps1
@@ -1,0 +1,35 @@
+<# 
+
+rEFInd background randomizer for Windows by ryanrudolf
+https://github.com/ryanrudolfoba/
+
+Prerequisites:
+
+Place png images that you wish to use as backgrounds for rEFInd here -
+C:\refind\backgrounds
+
+Place this script in a scheduled task to automatically run at startup.
+
+#>
+
+Clear-Host
+
+# set variables for ESP and random background
+Set-Variable -Name "ESP" -value (Compare-Object -PassThru (Get-PsDrive [A-Z]).Name ([char[]] 'DEFGHIJKLMNOPQRSTUVWXYZ') | Select-Object -first 1)
+Set-Variable -Name "RandomBackground" -value (Get-ChildItem -Path "c:\refind\backgrounds\*.png" | Get-Random -count 1)
+
+# mount ESP partition to the next available drive letter
+mountvol $ESP`: /s
+
+# do some error level checking and proceed accordingly
+if ($LASTEXITCODE -eq 0) { 
+Write-Host "So far so good. ESP partition has been mounted successfully to $ESP."
+Write-Host "Proceed to randomize background image and copy it over to $ESP`:\efi\refind\backgrounds."
+Copy-Item "$RandomBackground" -Destination "$ESP`:\efi\refind\backgrounds\background.png"
+mountvol $ESP`: /d
+Write-Host "All done! Background image has been randomized for rEFInd. ESP has been unmounted. Good bye!"
+exit}
+
+else {
+Write-Host "Error mounting ESP partition. Exiting immediately."
+exit}


### PR DESCRIPTION
PNG image files should be located in - C:\refind_scripts\backgrounds

The powershell script will mount the ESP partition to the next available drive letter, randomize the PNG and copy it to ESP:\efi\refind\backgrounds and finally unmount the ESP partition.

Put this in a scheduled task to execute automatically on startup.