### PR TITLE
Automate Arch package build in GitHub release flow

### DIFF
--- a/.github/workflows/arch-release.yml
+++ b/.github/workflows/arch-release.yml
@@ -1,0 +1,55 @@
+name: Arch Package Release
+
+# Builds the Arch/SteamOS package (.pkg.tar.zst) with makepkg inside an Arch
+# container and attaches it to the GitHub Release for the tag — replaces the
+# manual build previously done in a ChimeraOS VM.
+#
+# Runs automatically on version tags; workflow_dispatch takes an existing tag
+# so a package can be (re)built for a release after the fact.
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing v* tag to build and attach the package to'
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: archlinux:base-devel
+    env:
+      TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+    steps:
+      # Exact makedepends from the PKGBUILD (plus git for the source clone);
+      # makepkg then runs without -s, so a drifting PKGBUILD fails loudly here.
+      - name: Install build dependencies
+        run: pacman -Syu --noconfirm git cmake gcc glibc make qt5-base qt5-tools
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+
+      - name: Check PKGBUILD pkgver matches the tag
+        run: |
+          pkgver="$(sed -n 's/^pkgver=//p' PKGBUILD)"
+          if [ "v${pkgver}" != "${TAG}" ]; then
+            echo "::error::PKGBUILD pkgver=${pkgver} does not match tag ${TAG}; bump pkgver before tagging."
+            exit 1
+          fi
+
+      - name: Build package (makepkg)
+        run: |
+          useradd -m builder
+          chown -R builder: .
+          su builder -c 'makepkg --noconfirm'
+
+      - name: Attach package to release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.TAG }}
+          files: '*.pkg.tar.zst'

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -11,7 +11,9 @@ license=('MIT')
 depends=()
 makedepends=('cmake' 'gcc' 'glibc' 'make' 'qt5-base' 'qt5-tools')
 source=(
-    "SteamDeck_rEFInd::git+https://github.com/jlobue10/SteamDeck_rEFInd.git"
+    # Pinned to the release tag so rebuilding an old version never silently
+    # packages newer main-branch code.
+    "SteamDeck_rEFInd::git+https://github.com/jlobue10/SteamDeck_rEFInd.git#tag=v${pkgver}"
 )
 md5sums=(
     'SKIP'


### PR DESCRIPTION
Adds an `Arch Package Release` workflow that builds the Arch/SteamOS package with `makepkg` in an `archlinux:base-devel` container and attaches the `.pkg.tar.zst` to the GitHub Release — replacing the manual ChimeraOS VM build.

- Triggers on `v*` tag pushes, and via **workflow_dispatch** with a `tag` input to (re)build a package for an existing release (will be used to add the package to v2.0.0).
- Pins the PKGBUILD git source to `#tag=v${pkgver}` so rebuilding an old version can never silently package newer `main` code.
- Guard step fails early with a clear error if `pkgver` doesn't match the tag being built.
- Explicit `permissions: contents: write` so the release upload works regardless of repo-default token permissions (the issue that bit the v2.0.0 Windows release run).

Note: `post_install()` inside PKGBUILD is currently dead code (pacman only runs hooks from a separate `.install` file referenced via `install=`); left as-is deliberately — can wire it up in a follow-up if the service auto-enable is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)