### PR TITLE
Wire up post_install via .install file

### DIFF
--- a/.github/workflows/arch-release.yml
+++ b/.github/workflows/arch-release.yml
@@ -30,9 +30,12 @@ jobs:
       - name: Install build dependencies
         run: pacman -Syu --noconfirm git cmake gcc glibc make qt5-base qt5-tools
 
+      # Default checkout: the tag itself on tag pushes, the dispatched branch
+      # on manual runs. Either way the packaging recipe (PKGBUILD + .install)
+      # comes from that ref, while the packaged source is the tag the PKGBUILD
+      # pins — so dispatching from main rebuilds an old release with the
+      # current recipe, and the pkgver guard below keeps the pairing honest.
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
 
       - name: Check PKGBUILD pkgver matches the tag
         run: |

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -3,11 +3,12 @@
 _pkgname=SteamDeck_rEFInd
 pkgname=${_pkgname}
 pkgver=2.0.0
-pkgrel=1
+pkgrel=2
 pkgdesc='SteamDeck rEFInd installer and customization GUI'
 arch=('x86_64')
 url="https://github.com/jlobue10/SteamDeck_rEFInd"
 license=('MIT')
+install=${_pkgname}.install
 depends=()
 makedepends=('cmake' 'gcc' 'glibc' 'make' 'qt5-base' 'qt5-tools')
 source=(
@@ -37,11 +38,4 @@ package() {
 	install -Dm644 "${srcdir}/$_pkgname/SteamDeck_rEFInd.png" "${pkgdir}/usr/share/icons/hicolor/256x256/apps/SteamDeck_rEFInd.png"
         install -Dm644 "${srcdir}/$_pkgname/systemd/rEFInd_bg_randomizer.service" "${pkgdir}/etc/systemd/system/rEFInd_bg_randomizer.service"
         install -Dm644 "${srcdir}/$_pkgname/systemd/bootnext-refind.service" "${pkgdir}/etc/systemd/system/bootnext-refind.service"
-}
-
-post_install() {
-	systemctl daemon-reload
-	# Start and enable the bootnext-refind service
-	systemctl start bootnext-refind.service
-	systemctl enable bootnext-refind.service
 }

--- a/SteamDeck_rEFInd.install
+++ b/SteamDeck_rEFInd.install
@@ -1,0 +1,10 @@
+post_install() {
+	systemctl daemon-reload
+	# Start and enable the bootnext-refind service
+	systemctl start bootnext-refind.service
+	systemctl enable bootnext-refind.service
+}
+
+post_upgrade() {
+	post_install
+}


### PR DESCRIPTION
The `post_install()` function inside PKGBUILD was dead code — pacman only runs scriptlets from a separate file referenced via `install=`. This moves the systemd daemon-reload/start/enable logic into `SteamDeck_rEFInd.install` (and runs it on upgrades too), bumps `pkgrel` to 2, and makes the dispatch path of the Arch release workflow build the packaging recipe from the checked-out branch (the source itself stays pinned to the release tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)