### PR TITLE
Fix install-GUI.sh: select only the non-debug Arch package

### DIFF
--- a/install-GUI.sh
+++ b/install-GUI.sh
@@ -2,34 +2,34 @@
 
 # A simple script to install the rEFInd customization GUI
 sudo steamos-readonly disable
+# Make sure readonly gets re-enabled even if the script aborts partway through
+trap 'sudo steamos-readonly enable' EXIT
 echo -e "Installing SteamDeck rEFInd...\n"
 CURRENT_WD=$(pwd)
-mkdir -p $HOME/.local/SteamDeck_rEFInd
-cp -rf $CURRENT_WD/GUI/ $HOME/.local/SteamDeck_rEFInd
-cp -rf $CURRENT_WD/icons/ $HOME/.local/SteamDeck_rEFInd
-cp -rf $CURRENT_WD/backgrounds/ $HOME/.local/SteamDeck_rEFInd
-cp -rf $CURRENT_WD/scripts/ $HOME/.local/SteamDeck_rEFInd
-cp -f $CURRENT_WD/refind-GUI.conf $HOME/.local/SteamDeck_rEFInd/GUI/refind.conf
-chmod +x $HOME/.local/SteamDeck_rEFInd/scripts/*.sh
+mkdir -p "$HOME/.local/SteamDeck_rEFInd"
+cp -rf "$CURRENT_WD/GUI/" "$HOME/.local/SteamDeck_rEFInd"
+cp -rf "$CURRENT_WD/icons/" "$HOME/.local/SteamDeck_rEFInd"
+cp -rf "$CURRENT_WD/backgrounds/" "$HOME/.local/SteamDeck_rEFInd"
+cp -rf "$CURRENT_WD/scripts/" "$HOME/.local/SteamDeck_rEFInd"
+cp -f "$CURRENT_WD/refind-GUI.conf" "$HOME/.local/SteamDeck_rEFInd/GUI/refind.conf"
+chmod +x "$HOME"/.local/SteamDeck_rEFInd/scripts/*.sh
 
 #Clean up old installation...
-ls -l $HOME/.SteamDeck_rEFInd
-OLD_INSTALL_FOUND=$?
-if [ $OLD_INSTALL_FOUND == 0 ]; then
-    rm -rf $HOME/.SteamDeck_rEFInd
+if [ -d "$HOME/.SteamDeck_rEFInd" ]; then
+    rm -rf "$HOME/.SteamDeck_rEFInd"
 fi
 
 #Clean up old icon...
-ls -l $HOME/Desktop/refind_GUI.desktop
-OLD_ICON_FOUND=$?
-if [ $OLD_ICON_FOUND == 0 ]; then
-    rm -f $HOME/Desktop/refind_GUI.desktop
+if [ -f "$HOME/Desktop/refind_GUI.desktop" ]; then
+    rm -f "$HOME/Desktop/refind_GUI.desktop"
 fi
 
 # Thanks to Maclay74 steam-patch for the following syntax
-RELEASE=$(curl -s 'https://api.github.com/repos/jlobue10/SteamDeck_rEFInd/releases' | jq -r "first(.[] | select(.prerelease == "false"))")
+RELEASE=$(curl -s 'https://api.github.com/repos/jlobue10/SteamDeck_rEFInd/releases' | jq -r 'first(.[] | select(.prerelease == false))')
 VERSION=$(jq -r '.tag_name' <<< "${RELEASE}")
-DOWNLOAD_URL=$(jq -r '.assets[].browser_download_url | select(endswith("x86_64.pkg.tar.zst"))' <<< "${RELEASE}")
+# Releases also carry a -debug- split package (symbols only); install only the
+# regular package.
+DOWNLOAD_URL=$(jq -r 'first(.assets[].browser_download_url | select(endswith("x86_64.pkg.tar.zst") and (contains("-debug-") | not)))' <<< "${RELEASE}")
 
 if [ -z "$DOWNLOAD_URL" ] || [ "$DOWNLOAD_URL" == "null" ]; then
     echo "Error: could not determine a release download URL from the GitHub API. Aborting." >&2
@@ -44,31 +44,31 @@ if [ $? -ne 0 ] || [ ! -s "$INSTALL_PKG" ]; then
     exit 1
 fi
 
-sudo pacman -Qs SteamDeck_rEFInd
-STEAMDECK_REFIND_STATUS=$?
-if [ $STEAMDECK_REFIND_STATUS == 0 ]; then
+if pacman -Qs SteamDeck_rEFInd > /dev/null; then
     sudo pacman -R --noconfirm SteamDeck_rEFInd
 fi
 
-ls -l /etc/systemd/system/bootnext-refind.service
-OLD_REFIND_SERVICE=$?
-if [ $OLD_REFIND_SERVICE == 0 ]; then
+if [ -f /etc/systemd/system/bootnext-refind.service ]; then
     sudo systemctl disable --now bootnext-refind.service
     # Force removing old service file from previous versions
-    echo -e "\nRemoving old bootnext-refind.servce\n"
+    echo -e "\nRemoving old bootnext-refind.service\n"
     sudo rm /etc/systemd/system/bootnext-refind.service
 fi
 
-ls -l /etc/systemd/system/rEFInd_bg_randomizer.service
-OLD_BGRAND_SERVICE=$?
-if [ $OLD_BGRAND_SERVICE == 0 ]; then
+if [ -f /etc/systemd/system/rEFInd_bg_randomizer.service ]; then
     sudo systemctl disable --now rEFInd_bg_randomizer.service
     # Force removing old service file from previous versions
     echo -e "\nRemoving old rEFInd_bg_randomizer.service\n"
     sudo rm /etc/systemd/system/rEFInd_bg_randomizer.service
 fi
 
-sudo pacman -U --noconfirm "$INSTALL_PKG"
+# The package's post_install scriptlet handles daemon-reload plus enabling and
+# starting bootnext-refind.service.
+if ! sudo pacman -U --noconfirm "$INSTALL_PKG"; then
+    echo "Error: pacman failed to install $INSTALL_PKG. Aborting." >&2
+    exit 1
+fi
+rm -f "$INSTALL_PKG"
 
 # Leaving passwordless sudo stuff to try to fix another day...
 #Create file for passwordless sudo for config file, background and icon installation
@@ -80,16 +80,13 @@ sudo pacman -U --noconfirm "$INSTALL_PKG"
 
 #sudo cp $HOME/.local/SteamDeck_rEFInd/install_config_from_GUI /etc/sudoers.d 2>/dev/null
 
-sudo systemctl daemon-reload
-sudo systemctl enable --now bootnext-refind.service
-
 sudo steamos-readonly enable
 
-cp -f /usr/bin/SteamDeck_rEFInd $HOME/.local/SteamDeck_rEFInd/GUI/SteamDeck_rEFInd
-cp -f /usr/share/applications/SteamDeck_rEFInd.desktop $HOME/.local/SteamDeck_rEFInd/GUI/SteamDeck_rEFInd.desktop
+cp -f /usr/bin/SteamDeck_rEFInd "$HOME/.local/SteamDeck_rEFInd/GUI/SteamDeck_rEFInd"
+cp -f /usr/share/applications/SteamDeck_rEFInd.desktop "$HOME/.local/SteamDeck_rEFInd/GUI/SteamDeck_rEFInd.desktop"
 # Desktop file ships with /home/deck hardcoded; rewrite it for the actual user's home
-sed -i "s|/home/deck|$HOME|g" $HOME/.local/SteamDeck_rEFInd/GUI/SteamDeck_rEFInd.desktop
-cp -f $HOME/.local/SteamDeck_rEFInd/GUI/SteamDeck_rEFInd.desktop $HOME/Desktop/SteamDeck_rEFInd.desktop
-chmod +x $HOME/.local/SteamDeck_rEFInd/GUI/SteamDeck_rEFInd.desktop
-chmod +x $HOME/Desktop/SteamDeck_rEFInd.desktop
+sed -i "s|/home/deck|$HOME|g" "$HOME/.local/SteamDeck_rEFInd/GUI/SteamDeck_rEFInd.desktop"
+cp -f "$HOME/.local/SteamDeck_rEFInd/GUI/SteamDeck_rEFInd.desktop" "$HOME/Desktop/SteamDeck_rEFInd.desktop"
+chmod +x "$HOME/.local/SteamDeck_rEFInd/GUI/SteamDeck_rEFInd.desktop"
+chmod +x "$HOME/Desktop/SteamDeck_rEFInd.desktop"
 echo -e "Installation complete...\n"


### PR DESCRIPTION
The v2.0.0 release ships a `-debug-` split package alongside the regular one, so the jq asset filter matched **two** URLs — the multi-line result broke `wget` and the install. Verified against the live releases API: the new filter (`first(...)` + `-debug-` excluded) returns exactly the regular package.

Other fixes while in here:
- EXIT trap re-enables `steamos-readonly` on early aborts (previously the deck stayed writable if the script bailed at the download/API checks)
- `pacman -U` failure now aborts instead of continuing to copy stale/missing files from `/usr`
- Dropped the manual `daemon-reload`/`enable --now` — the package's `post_install` scriptlet (since 2.0.0-2) handles it
- `ls -l`+`$?` existence checks replaced with `[ -f ]`/`[ -d ]`; path expansions quoted; downloaded package cleaned up after install; prerelease jq filter properly single-quoted (previously depended on shell quote-stripping to work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)