### PR TITLE
Fix and harden the Windows background randomizer

### DIFF
--- a/Windows/GUI/install_config_from_GUI.ps1
+++ b/Windows/GUI/install_config_from_GUI.ps1
@@ -9,6 +9,16 @@ $ErrorActionPreference = 'Stop'
 $EspGuid = '{c12a7328-f81f-11d2-ba4b-00a0c93ec93b}'
 $RefindLoader = 'EFI\refind\refind_x64.efi'
 
+# mountvol reports failure on stderr, which Windows PowerShell 5.1 turns into a
+# terminating RemoteException when redirected under ErrorActionPreference Stop;
+# run it with the preference relaxed so a failed mount stays a plain exit code.
+function Invoke-Mountvol([string[]]$mvArgs) {
+    $eap = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try { mountvol @mvArgs 2>$null | Out-Null } finally { $ErrorActionPreference = $eap }
+    return $LASTEXITCODE
+}
+
 # Make a specific ESP partition reachable, returning its filesystem root and how
 # it was mounted. Handles: an already-lettered ESP, the letterless system ESP
 # (mountvol /S), and a letterless non-system ESP (temporary directory access
@@ -21,8 +31,7 @@ function Mount-EspPartition($part) {
         $used = (Get-PSDrive -PSProvider FileSystem).Name
         foreach ($c in 'Z','Y','X','W','V','U','T') {
             if ($used -notcontains $c) {
-                mountvol "${c}:" /S 2>$null | Out-Null
-                if ($LASTEXITCODE -eq 0) {
+                if ((Invoke-Mountvol @("${c}:", '/S')) -eq 0) {
                     return @{ Root = "${c}:"; Kind = 'mountvol' }
                 }
             }
@@ -38,7 +47,7 @@ function Mount-EspPartition($part) {
 
 function Dismount-Esp($m) {
     switch ($m.Kind) {
-        'mountvol' { mountvol $m.Root /D | Out-Null }
+        'mountvol' { $null = Invoke-Mountvol @($m.Root, '/D') }
         'accesspath' {
             Remove-PartitionAccessPath -DiskNumber $m.DiskNumber -PartitionNumber $m.PartitionNumber `
                 -AccessPath $m.Dir -ErrorAction SilentlyContinue

--- a/Windows/GUI/install_rEFInd.ps1
+++ b/Windows/GUI/install_rEFInd.ps1
@@ -12,6 +12,16 @@ $RefindVer = '0.14.2'
 $EspGuid = '{c12a7328-f81f-11d2-ba4b-00a0c93ec93b}'
 $RefindLoader = '\EFI\refind\refind_x64.efi'
 
+# mountvol reports failure on stderr, which Windows PowerShell 5.1 turns into a
+# terminating RemoteException when redirected under ErrorActionPreference Stop;
+# run it with the preference relaxed so a failed mount stays a plain exit code.
+function Invoke-Mountvol([string[]]$mvArgs) {
+    $eap = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try { mountvol @mvArgs 2>$null | Out-Null } finally { $ErrorActionPreference = $eap }
+    return $LASTEXITCODE
+}
+
 function Mount-Esp {
     $esp = Get-Partition | Where-Object { $_.GptType -eq $EspGuid -and $_.IsSystem } | Select-Object -First 1
     if ($esp -and $esp.DriveLetter) {
@@ -20,8 +30,7 @@ function Mount-Esp {
     $used = (Get-PSDrive -PSProvider FileSystem).Name
     foreach ($c in 'Z','Y','X','W','V','U','T') {
         if ($used -notcontains $c) {
-            mountvol "${c}:" /S 2>$null | Out-Null
-            if ($LASTEXITCODE -eq 0) {
+            if ((Invoke-Mountvol @("${c}:", '/S')) -eq 0) {
                 return @{ Root = "${c}:"; Dismount = $true }
             }
         }
@@ -30,7 +39,7 @@ function Mount-Esp {
 }
 
 function Dismount-Esp($esp) {
-    if ($esp.Dismount) { mountvol $esp.Root /D | Out-Null }
+    if ($esp.Dismount) { $null = Invoke-Mountvol @($esp.Root, '/D') }
 }
 
 # bcdedit is a native exe: under $ErrorActionPreference = 'Stop' a failed call

--- a/Windows/GUI/rEFInd_bg_randomizer.ps1
+++ b/Windows/GUI/rEFInd_bg_randomizer.ps1
@@ -1,45 +1,112 @@
 #Requires -RunAsAdministrator
-# Copies a random background PNG to the rEFInd directory on the EFI System
-# Partition. Run at logon by the "rEFInd_bg_randomizer" scheduled task.
+# Copies a random background PNG to rEFInd's directory on whichever EFI System
+# Partition actually contains rEFInd (on multi-ESP machines that may not be the
+# system ESP). Run hidden at logon by the "rEFInd_bg_randomizer" scheduled
+# task, so progress and errors are also written to rEFInd_bg_randomizer.log in
+# the app data directory.
 $ErrorActionPreference = 'Stop'
 
 $EspGuid = '{c12a7328-f81f-11d2-ba4b-00a0c93ec93b}'
+$RefindLoader = 'EFI\refind\refind_x64.efi'
+$DataDir = Join-Path $env:LOCALAPPDATA 'SteamDeck_rEFInd'
+$LogFile = Join-Path $DataDir 'rEFInd_bg_randomizer.log'
 
-function Mount-Esp {
-    $esp = Get-Partition | Where-Object { $_.GptType -eq $EspGuid -and $_.IsSystem } | Select-Object -First 1
-    if ($esp -and $esp.DriveLetter) {
-        return @{ Root = "$($esp.DriveLetter):"; Dismount = $false }
+Set-Content -Path $LogFile -Value @() -ErrorAction SilentlyContinue
+function Log($msg) {
+    $line = '[{0}] {1}' -f (Get-Date -Format 'yyyy-MM-dd HH:mm:ss'), $msg
+    Write-Host $line
+    Add-Content -Path $LogFile -Value $line -ErrorAction SilentlyContinue
+}
+
+# mountvol reports failure on stderr, which Windows PowerShell 5.1 turns into a
+# terminating RemoteException when redirected under ErrorActionPreference Stop;
+# run it with the preference relaxed so a failed mount stays a plain exit code.
+function Invoke-Mountvol([string[]]$mvArgs) {
+    $eap = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try { mountvol @mvArgs 2>$null | Out-Null } finally { $ErrorActionPreference = $eap }
+    return $LASTEXITCODE
+}
+
+# Make a specific ESP partition reachable, returning its filesystem root and how
+# it was mounted. Handles: an already-lettered ESP, the letterless system ESP
+# (mountvol /S), and a letterless non-system ESP (temporary directory access
+# path, which does not consume a drive letter).
+function Mount-EspPartition($part) {
+    if ([char]::IsLetter([char]$part.DriveLetter)) {
+        return @{ Root = "$($part.DriveLetter):"; Kind = 'letter' }
     }
-    $used = (Get-PSDrive -PSProvider FileSystem).Name
-    foreach ($c in 'Z','Y','X','W','V','U','T') {
-        if ($used -notcontains $c) {
-            mountvol "${c}:" /S 2>$null | Out-Null
-            if ($LASTEXITCODE -eq 0) {
-                return @{ Root = "${c}:"; Dismount = $true }
+    if ($part.IsSystem) {
+        $used = (Get-PSDrive -PSProvider FileSystem).Name
+        foreach ($c in 'Z','Y','X','W','V','U','T') {
+            if ($used -notcontains $c) {
+                if ((Invoke-Mountvol @("${c}:", '/S')) -eq 0) {
+                    return @{ Root = "${c}:"; Kind = 'mountvol' }
+                }
             }
         }
+        throw 'Could not mount the system EFI System Partition.'
     }
-    throw 'Could not mount the EFI System Partition. Run this script as Administrator.'
+    $dir = Join-Path $env:TEMP ('refind-esp-' + [guid]::NewGuid().ToString('N'))
+    New-Item -ItemType Directory -Force $dir | Out-Null
+    Add-PartitionAccessPath -DiskNumber $part.DiskNumber -PartitionNumber $part.PartitionNumber -AccessPath $dir
+    return @{ Root = $dir; Kind = 'accesspath'; DiskNumber = $part.DiskNumber;
+              PartitionNumber = $part.PartitionNumber; Dir = $dir }
 }
 
-function Dismount-Esp($esp) {
-    if ($esp.Dismount) { mountvol $esp.Root /D | Out-Null }
+function Dismount-Esp($m) {
+    switch ($m.Kind) {
+        'mountvol' { $null = Invoke-Mountvol @($m.Root, '/D') }
+        'accesspath' {
+            Remove-PartitionAccessPath -DiskNumber $m.DiskNumber -PartitionNumber $m.PartitionNumber `
+                -AccessPath $m.Dir -ErrorAction SilentlyContinue
+            Remove-Item -Force -ErrorAction SilentlyContinue $m.Dir
+        }
+    }
 }
 
-$bgDir = Join-Path $env:LOCALAPPDATA 'SteamDeck_rEFInd\backgrounds'
-$bg = Get-ChildItem -Path $bgDir -Filter '*.png' -File -ErrorAction SilentlyContinue | Get-Random -ErrorAction SilentlyContinue
-if (-not $bg) {
-    Write-Host "No PNG backgrounds found in $bgDir"
-    exit 0
-}
-
-$esp = Mount-Esp
 try {
-    $dest = Join-Path $esp.Root 'EFI\refind'
-    if (Test-Path $dest) {
-        Copy-Item -Force $bg.FullName (Join-Path $dest 'background.png')
-        Write-Host "Background set to $($bg.Name)"
+    $bgDir = Join-Path $DataDir 'backgrounds'
+    $pngs = @(Get-ChildItem -Path $bgDir -Filter '*.png' -File -ErrorAction SilentlyContinue)
+    if (-not $pngs) {
+        Log "No PNG backgrounds found in $bgDir; nothing to do."
+        exit 0
     }
-} finally {
-    Dismount-Esp $esp
+
+    # Pick the ESP that actually contains rEFInd, system ESP first.
+    $esps = @(Get-Partition | Where-Object { $_.GptType -eq $EspGuid })
+    $ordered = @($esps | Where-Object { $_.IsSystem }) + @($esps | Where-Object { -not $_.IsSystem })
+    $mount = $null
+    foreach ($p in $ordered) {
+        try { $m = Mount-EspPartition $p } catch {
+            Log "Skipping unreachable ESP (disk $($p.DiskNumber) partition $($p.PartitionNumber)): $_"
+            continue
+        }
+        if (Test-Path (Join-Path $m.Root $RefindLoader)) { $mount = $m; break }
+        Dismount-Esp $m
+    }
+    if (-not $mount) {
+        Log 'rEFInd was not found on any EFI System Partition; nothing to do.'
+        exit 0
+    }
+
+    try {
+        $destBg = Join-Path $mount.Root 'EFI\refind\background.png'
+        # With more than one background available, avoid re-picking the one
+        # that is already installed.
+        $candidates = $pngs
+        if ($pngs.Count -gt 1 -and (Test-Path $destBg)) {
+            $current = (Get-FileHash -Algorithm SHA256 $destBg).Hash
+            $fresh = @($pngs | Where-Object { (Get-FileHash -Algorithm SHA256 $_.FullName).Hash -ne $current })
+            if ($fresh.Count) { $candidates = $fresh }
+        }
+        $bg = $candidates | Get-Random
+        Copy-Item -Force $bg.FullName $destBg
+        Log "Background set to $($bg.Name)"
+    } finally {
+        Dismount-Esp $mount
+    }
+} catch {
+    Log "ERROR: $_"
+    exit 1
 }

--- a/Windows/GUI/rEFInd_bg_randomizer_task.ps1
+++ b/Windows/GUI/rEFInd_bg_randomizer_task.ps1
@@ -8,7 +8,9 @@ param(
 $ErrorActionPreference = 'Stop'
 
 $taskName = 'rEFInd_bg_randomizer'
-$script = Join-Path $env:LOCALAPPDATA 'SteamDeck_rEFInd\windows\rEFInd_bg_randomizer.ps1'
+$dataDir = Join-Path $env:LOCALAPPDATA 'SteamDeck_rEFInd'
+$script = Join-Path $dataDir 'windows\rEFInd_bg_randomizer.ps1'
+$logFile = Join-Path $dataDir 'rEFInd_bg_randomizer.log'
 
 if ($Enable) {
     if (-not (Test-Path $script)) {
@@ -18,9 +20,29 @@ if ($Enable) {
         -Argument "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$script`""
     $trigger = New-ScheduledTaskTrigger -AtLogOn -User $env:USERNAME
     $principal = New-ScheduledTaskPrincipal -UserId $env:USERNAME -RunLevel Highest -LogonType Interactive
-    Register-ScheduledTask -TaskName $taskName -Action $action -Trigger $trigger -Principal $principal -Force | Out-Null
+    # Without explicit settings a scheduled task refuses to start on battery
+    # power, which on a handheld means it would almost never run at logon.
+    $settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries `
+        -StartWhenAvailable -MultipleInstances IgnoreNew -ExecutionTimeLimit (New-TimeSpan -Minutes 5)
+    Register-ScheduledTask -TaskName $taskName -Action $action -Trigger $trigger `
+        -Principal $principal -Settings $settings -Force | Out-Null
+    Write-Host 'Background randomizer task enabled (runs at each logon). Running it once now...'
     Start-ScheduledTask -TaskName $taskName
-    Write-Host "Background randomizer task enabled (runs at logon)."
+    Start-Sleep -Seconds 1
+    $deadline = (Get-Date).AddSeconds(30)
+    while ((Get-ScheduledTask -TaskName $taskName).State -eq 'Running' -and (Get-Date) -lt $deadline) {
+        Start-Sleep -Milliseconds 500
+    }
+    $result = (Get-ScheduledTaskInfo -TaskName $taskName).LastTaskResult
+    if ($result -eq 0) {
+        Write-Host 'First run finished successfully.'
+    } else {
+        Write-Host "First run finished with result code $result."
+    }
+    if (Test-Path $logFile) {
+        Write-Host "--- $logFile ---"
+        Get-Content $logFile | ForEach-Object { Write-Host $_ }
+    }
 } elseif ($Disable) {
     Unregister-ScheduledTask -TaskName $taskName -Confirm:$false -ErrorAction SilentlyContinue
     Write-Host 'Background randomizer task disabled.'

--- a/Windows/rEFInd Background Randomizer/refind_bg_randomizer.ps1
+++ b/Windows/rEFInd Background Randomizer/refind_bg_randomizer.ps1
@@ -1,4 +1,5 @@
-<# 
+#Requires -RunAsAdministrator
+<#
 
 rEFInd background randomizer for Windows by ryanrudolf
 https://github.com/ryanrudolfoba/
@@ -8,28 +9,121 @@ Prerequisites:
 Place png images that you wish to use as backgrounds for rEFInd here -
 C:\refind_scripts\backgrounds
 
-Place this script in a scheduled task to automatically run at startup.
+Your refind.conf must reference the randomized image, e.g.:
+banner backgrounds/background.png
+
+Place this script in a scheduled task to automatically run at startup. In the
+task, enable "Run with highest privileges" and (under Conditions) untick
+"Start the task only if the computer is on AC power" so it also runs on
+battery. Progress and errors are written to
+C:\refind_scripts\refind_bg_randomizer.log.
 
 #>
+$ErrorActionPreference = 'Stop'
 
-Clear-Host
+$EspGuid = '{c12a7328-f81f-11d2-ba4b-00a0c93ec93b}'
+$RefindLoader = 'EFI\refind\refind_x64.efi'
+$ScriptsDir = 'C:\refind_scripts'
+$LogFile = Join-Path $ScriptsDir 'refind_bg_randomizer.log'
 
-# set variables for ESP and random background
-Set-Variable -Name "ESP" -value (Compare-Object -PassThru (Get-PsDrive [A-Z]).Name ([char[]] 'DEFGHIJKLMNOPQRSTUVWXYZ') | Select-Object -first 1)
-Set-Variable -Name "RandomBackground" -value (Get-ChildItem -Path "c:\refind_scripts\backgrounds\*.png" | Get-Random -count 1)
+Set-Content -Path $LogFile -Value @() -ErrorAction SilentlyContinue
+function Log($msg) {
+    $line = '[{0}] {1}' -f (Get-Date -Format 'yyyy-MM-dd HH:mm:ss'), $msg
+    Write-Host $line
+    Add-Content -Path $LogFile -Value $line -ErrorAction SilentlyContinue
+}
 
-# mount ESP partition to the next available drive letter
-mountvol $ESP`: /s
+# mountvol reports failure on stderr, which Windows PowerShell 5.1 turns into a
+# terminating RemoteException when redirected under ErrorActionPreference Stop;
+# run it with the preference relaxed so a failed mount stays a plain exit code.
+function Invoke-Mountvol([string[]]$mvArgs) {
+    $eap = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try { mountvol @mvArgs 2>$null | Out-Null } finally { $ErrorActionPreference = $eap }
+    return $LASTEXITCODE
+}
 
-# do some error level checking and proceed accordingly
-if ($LASTEXITCODE -eq 0) { 
-Write-Host "So far so good. ESP partition has been mounted successfully to $ESP."
-Write-Host "Proceed to randomize background image and copy it over to $ESP`:\efi\refind\backgrounds."
-Copy-Item "$RandomBackground" -Destination "$ESP`:\efi\refind\backgrounds\background.png"
-mountvol $ESP`: /d
-Write-Host "All done! Background image has been randomized for rEFInd. ESP has been unmounted. Good bye!"
-exit}
+# Make a specific ESP partition reachable, returning its filesystem root and how
+# it was mounted. Handles: an already-lettered ESP, the letterless system ESP
+# (mountvol /S), and a letterless non-system ESP (temporary directory access
+# path, which does not consume a drive letter).
+function Mount-EspPartition($part) {
+    if ([char]::IsLetter([char]$part.DriveLetter)) {
+        return @{ Root = "$($part.DriveLetter):"; Kind = 'letter' }
+    }
+    if ($part.IsSystem) {
+        $used = (Get-PSDrive -PSProvider FileSystem).Name
+        foreach ($c in 'Z','Y','X','W','V','U','T') {
+            if ($used -notcontains $c) {
+                if ((Invoke-Mountvol @("${c}:", '/S')) -eq 0) {
+                    return @{ Root = "${c}:"; Kind = 'mountvol' }
+                }
+            }
+        }
+        throw 'Could not mount the system EFI System Partition.'
+    }
+    $dir = Join-Path $env:TEMP ('refind-esp-' + [guid]::NewGuid().ToString('N'))
+    New-Item -ItemType Directory -Force $dir | Out-Null
+    Add-PartitionAccessPath -DiskNumber $part.DiskNumber -PartitionNumber $part.PartitionNumber -AccessPath $dir
+    return @{ Root = $dir; Kind = 'accesspath'; DiskNumber = $part.DiskNumber;
+              PartitionNumber = $part.PartitionNumber; Dir = $dir }
+}
 
-else {
-Write-Host "Error mounting ESP partition. Exiting immediately."
-exit}
+function Dismount-Esp($m) {
+    switch ($m.Kind) {
+        'mountvol' { $null = Invoke-Mountvol @($m.Root, '/D') }
+        'accesspath' {
+            Remove-PartitionAccessPath -DiskNumber $m.DiskNumber -PartitionNumber $m.PartitionNumber `
+                -AccessPath $m.Dir -ErrorAction SilentlyContinue
+            Remove-Item -Force -ErrorAction SilentlyContinue $m.Dir
+        }
+    }
+}
+
+try {
+    $bgDir = Join-Path $ScriptsDir 'backgrounds'
+    $pngs = @(Get-ChildItem -Path $bgDir -Filter '*.png' -File -ErrorAction SilentlyContinue)
+    if (-not $pngs) {
+        Log "No PNG backgrounds found in $bgDir; nothing to do."
+        exit 0
+    }
+
+    # Pick the ESP that actually contains rEFInd, system ESP first.
+    $esps = @(Get-Partition | Where-Object { $_.GptType -eq $EspGuid })
+    $ordered = @($esps | Where-Object { $_.IsSystem }) + @($esps | Where-Object { -not $_.IsSystem })
+    $mount = $null
+    foreach ($p in $ordered) {
+        try { $m = Mount-EspPartition $p } catch {
+            Log "Skipping unreachable ESP (disk $($p.DiskNumber) partition $($p.PartitionNumber)): $_"
+            continue
+        }
+        if (Test-Path (Join-Path $m.Root $RefindLoader)) { $mount = $m; break }
+        Dismount-Esp $m
+    }
+    if (-not $mount) {
+        Log 'rEFInd was not found on any EFI System Partition; nothing to do.'
+        exit 0
+    }
+
+    try {
+        $destDir = Join-Path $mount.Root 'EFI\refind\backgrounds'
+        New-Item -ItemType Directory -Force $destDir | Out-Null
+        $destBg = Join-Path $destDir 'background.png'
+        # With more than one background available, avoid re-picking the one
+        # that is already installed.
+        $candidates = $pngs
+        if ($pngs.Count -gt 1 -and (Test-Path $destBg)) {
+            $current = (Get-FileHash -Algorithm SHA256 $destBg).Hash
+            $fresh = @($pngs | Where-Object { (Get-FileHash -Algorithm SHA256 $_.FullName).Hash -ne $current })
+            if ($fresh.Count) { $candidates = $fresh }
+        }
+        $bg = $candidates | Get-Random
+        Copy-Item -Force $bg.FullName $destBg
+        Log "Background set to $($bg.Name)"
+    } finally {
+        Dismount-Esp $mount
+    }
+} catch {
+    Log "ERROR: $_"
+    exit 1
+}


### PR DESCRIPTION
## Summary
- Register the randomizer scheduled task with explicit settings so it starts on battery power (the defaults blocked battery starts, so on a Deck the logon trigger almost never fired), plus StartWhenAvailable, single-instance, and a 5-minute execution cap
- Make the GUI randomizer target whichever ESP actually contains `EFI\refind\refind_x64.efi` (same multi-ESP discovery as `install_config_from_GUI.ps1`) instead of silently no-opping when rEFInd isn't on the system ESP
- Log every randomizer run to a log file (the task runs hidden, so failures were invisible); after `-Enable`, run the task once and show the result and log in the visible window
- Avoid re-picking the background already installed (hash compare)
- Modernize the legacy manual `Windows/rEFInd Background Randomizer/refind_bg_randomizer.ps1` with the same hardening while keeping its `C:\refind_scripts\backgrounds` → `EFI\refind\backgrounds\background.png` contract and attribution; replaces the fragile drive-letter arithmetic that could pick A:/B: or an in-use letter
- Route all `mountvol` calls (randomizers, `install_config_from_GUI.ps1`, `install_rEFInd.ps1`) through an `Invoke-Mountvol` wrapper: under `$ErrorActionPreference='Stop'`, Windows PowerShell 5.1 turns a native command's redirected stderr into a terminating `RemoteException` (verified live), so a failed `mountvol X: /S` killed the script instead of trying the next drive letter

## Test plan
- All scripts parse clean under Windows PowerShell 5.1
- ESP discovery exercised live (mount system ESP, detect loader + background, dismount)
- `Invoke-Mountvol` verified to survive a failing mountvol call under EAP Stop
- Repeat-avoidance selection fixture-tested (30 draws, current background never re-picked; single-background edge still works)
- Scheduled-task settings object verified (`DisallowStartIfOnBatteries: False`, `StartWhenAvailable: True`, `MultipleInstances: IgnoreNew`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)