### PR TITLE
Add Open Folder button and a backgrounds shortcut in the GUI folder

### DIFF
--- a/GUI/src/mainwindow.cpp
+++ b/GUI/src/mainwindow.cpp
@@ -3,6 +3,7 @@
 #include "osdetect.h"
 #include "platform.h"
 
+#include <QDesktopServices>
 #include <QDir>
 #include <QFile>
 #include <QFileDialog>
@@ -14,6 +15,7 @@
 #include <QRegularExpression>
 #include <QSettings>
 #include <QTextStream>
+#include <QUrl>
 #include <QVariant>
 #include <QVersionNumber>
 
@@ -582,4 +584,12 @@ void MainWindow::on_Rand_BG_Off_pushButton_clicked()
     if (!Platform::setBackgroundRandomizer(false))
         QMessageBox::warning(this, tr("Background Randomizer"),
                              tr("Failed to launch the randomizer setup."));
+}
+
+void MainWindow::on_Open_Folder_pushButton_clicked()
+{
+    if (!QDesktopServices::openUrl(QUrl::fromLocalFile(guiConfigDir)))
+        QMessageBox::warning(this, tr("Open Folder"),
+                             tr("Failed to open %1 in the file manager.")
+                                 .arg(QDir::toNativeSeparators(guiConfigDir)));
 }

--- a/GUI/src/mainwindow.h
+++ b/GUI/src/mainwindow.h
@@ -42,6 +42,7 @@ private slots:
     void on_Disable_sysd_pushButton_clicked();
     void on_Rand_BG_On_pushButton_clicked();
     void on_Rand_BG_Off_pushButton_clicked();
+    void on_Open_Folder_pushButton_clicked();
 
 private:
     void readSettings();

--- a/GUI/src/mainwindow.ui
+++ b/GUI/src/mainwindow.ui
@@ -402,6 +402,28 @@
        </property>
       </widget>
      </item>
+     <item row="8" column="4" alignment="Qt::AlignRight">
+      <widget class="QPushButton" name="Open_Folder_pushButton">
+       <property name="minimumSize">
+        <size>
+         <width>92</width>
+         <height>32</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>92</width>
+         <height>32</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string>Open the folder holding refind.conf and the background/icon PNGs</string>
+       </property>
+       <property name="text">
+        <string>Open Folder</string>
+       </property>
+      </widget>
+     </item>
      <item row="8" column="5">
       <widget class="QPushButton" name="Disable_sysd_pushButton">
        <property name="minimumSize">

--- a/Windows/GUI/SteamDeck_rEFInd.iss
+++ b/Windows/GUI/SteamDeck_rEFInd.iss
@@ -42,6 +42,9 @@ Source: "..\..\deploy\*"; DestDir: "{app}"; Flags: recursesubdirs createallsubdi
 Name: "{group}\{#AppName}"; Filename: "{app}\{#AppExe}"; WorkingDir: "{app}"
 Name: "{group}\Uninstall {#AppName}"; Filename: "{uninstallexe}"
 Name: "{autodesktop}\{#AppName}"; Filename: "{app}\{#AppExe}"; WorkingDir: "{app}"; Tasks: desktopicon
+; Shortcut inside GUI\ (the folder the app's Open Folder button shows) to the
+; backgrounds folder the randomizer picks from.
+Name: "{app}\GUI\backgrounds"; Filename: "{app}\backgrounds"
 
 [Run]
 Filename: "{app}\{#AppExe}"; Description: "Launch {#AppName}"; Flags: nowait postinstall skipifsilent runascurrentuser

--- a/Windows/GUI/install-SteamDeck_rEFInd-GUI.ps1
+++ b/Windows/GUI/install-SteamDeck_rEFInd-GUI.ps1
@@ -27,6 +27,14 @@ New-Item -ItemType Directory -Force (Join-Path $dest 'windows') | Out-Null
 Copy-Item -Force (Join-Path $PSScriptRoot '*.ps1') (Join-Path $dest 'windows')
 Copy-Item -Force (Join-Path $repo 'refind-GUI.conf') (Join-Path $dest 'GUI\refind.conf')
 
+$ws = New-Object -ComObject WScript.Shell
+# Shortcut inside GUI\ (the folder the app's Open Folder button shows) to the
+# backgrounds folder the randomizer picks from.
+$bgLnk = $ws.CreateShortcut((Join-Path $dest 'GUI\backgrounds.lnk'))
+$bgLnk.TargetPath = Join-Path $dest 'backgrounds'
+$bgLnk.Description = 'Backgrounds used by the rEFInd background randomizer'
+$bgLnk.Save()
+
 if ($ExePath -and (Test-Path $ExePath)) {
     $exeDir = Split-Path -Parent $ExePath
     Copy-Item -Force $ExePath (Join-Path $dest 'SteamDeck_rEFInd.exe')
@@ -43,7 +51,6 @@ if ($ExePath -and (Test-Path $ExePath)) {
 
 $exeTarget = Join-Path $dest 'SteamDeck_rEFInd.exe'
 if (Test-Path $exeTarget) {
-    $ws = New-Object -ComObject WScript.Shell
     $startMenu = Join-Path ([Environment]::GetFolderPath('StartMenu')) 'Programs'
     foreach ($lnkDir in ([Environment]::GetFolderPath('Desktop')), $startMenu) {
         if (-not (Test-Path $lnkDir)) { continue }

--- a/install-GUI.sh
+++ b/install-GUI.sh
@@ -12,6 +12,9 @@ cp -rf "$CURRENT_WD/icons/" "$HOME/.local/SteamDeck_rEFInd"
 cp -rf "$CURRENT_WD/backgrounds/" "$HOME/.local/SteamDeck_rEFInd"
 cp -rf "$CURRENT_WD/scripts/" "$HOME/.local/SteamDeck_rEFInd"
 cp -f "$CURRENT_WD/refind-GUI.conf" "$HOME/.local/SteamDeck_rEFInd/GUI/refind.conf"
+# Shortcut inside GUI/ (the folder the app's Open Folder button shows) to the
+# backgrounds folder the randomizer picks from.
+ln -sfn ../backgrounds "$HOME/.local/SteamDeck_rEFInd/GUI/backgrounds"
 chmod +x "$HOME"/.local/SteamDeck_rEFInd/scripts/*.sh
 
 #Clean up old installation...


### PR DESCRIPTION
## Summary
- New **Open Folder** button (row 8, left of "Sysd Off" — this layout has no Exit button) that opens `<dataDir>/GUI` — where `refind.conf`, `background.png`, and `os_icon1..4.png` are staged — in the system file manager via `QDesktopServices`, with a warning dialog if the launch fails.
- Installers now create a **`backgrounds` shortcut inside `GUI/`** pointing at `<dataDir>/backgrounds`, the folder the background randomizer picks from:
  - `install-GUI.sh`: relative symlink (`ln -sfn ../backgrounds`), idempotent across reinstalls.
  - `Windows/GUI/install-SteamDeck_rEFInd-GUI.ps1`: `GUI\backgrounds.lnk` via WScript.Shell (COM object hoisted so it's created once).
  - `Windows/GUI/SteamDeck_rEFInd.iss`: `[Icons]` entry so the packaged installer creates the same `.lnk` and removes it on uninstall.

Mirrors jlobue10/rEFInd_GUI#37.

## Testing
- Built cleanly with MSYS2 UCRT64 (Qt6/Ninja).
- `bash -n` on the shell installer; PowerShell AST parse on the ps1.
- Smoke-tested folder-shortcut creation: resulting `.lnk` resolves to the backgrounds folder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)