### PR TITLE
Remember the last browse folder across PNG file dialogs

### DIFF
--- a/GUI/src/mainwindow.cpp
+++ b/GUI/src/mainwindow.cpp
@@ -224,9 +224,17 @@ void MainWindow::on_Rescan_pushButton_clicked()
 
 void MainWindow::browsePng(QLineEdit *edit, const QString &title)
 {
-    const QString fileName = QFileDialog::getOpenFileName(this, title, homePath, tr("Image (*.png)"));
-    if (!fileName.isEmpty())
+    // Reopen the folder the previous browse picked from; fall back to the
+    // home directory when there's no history or that folder no longer
+    // exists (deleted, or a settings file carried over from another setup).
+    QString startDir = lastBrowseDir;
+    if (startDir.isEmpty() || !QDir(startDir).exists())
+        startDir = homePath;
+    const QString fileName = QFileDialog::getOpenFileName(this, title, startDir, tr("Image (*.png)"));
+    if (!fileName.isEmpty()) {
         edit->setText(fileName);
+        lastBrowseDir = QFileInfo(fileName).absolutePath();
+    }
 }
 
 void MainWindow::on_Background_pushButton_clicked()
@@ -471,6 +479,10 @@ void MainWindow::readSettings()
     const QString timeout = settings.value(QStringLiteral("Timeout")).toString();
     settings.endGroup();
 
+    settings.beginGroup(QStringLiteral("Paths"));
+    lastBrowseDir = settings.value(QStringLiteral("LastBrowseDir")).toString();
+    settings.endGroup();
+
     populateBootCombos();
     if (boot1.isEmpty() && boot2.isEmpty() && boot3.isEmpty() && boot4.isEmpty()) {
         applyAutoSelection();
@@ -508,6 +520,9 @@ void MainWindow::writeSettings()
     settings.endGroup();
     settings.beginGroup(QStringLiteral("Timeout"));
     settings.setValue(QStringLiteral("Timeout"), ui->TimeOut_lineEdit->text());
+    settings.endGroup();
+    settings.beginGroup(QStringLiteral("Paths"));
+    settings.setValue(QStringLiteral("LastBrowseDir"), lastBrowseDir);
     settings.endGroup();
 }
 

--- a/GUI/src/mainwindow.h
+++ b/GUI/src/mainwindow.h
@@ -62,6 +62,7 @@ private:
 
     Ui::MainWindow *ui;
     QString homePath;
+    QString lastBrowseDir; // last folder a browse dialog picked from
     QString guiDataDir;   // Platform::dataDir()
     QString guiConfigDir; // <dataDir>/GUI
     QString settingsPath;


### PR DESCRIPTION
## Summary
The Background and OS Icon **Browse** buttons always opened in the home directory. They now reopen in the folder the previous browse picked from, and the location is persisted in `rEFInd_GUI.ini` (`Paths/LastBrowseDir`) so it survives app restarts.

**Sanity check:** if the remembered folder no longer exists (deleted, or a settings file carried over from another machine/setup), the dialog falls back to the previous default (home directory).

Same patch as the sibling rEFInd_GUI repo; shared `mainwindow.cpp` code covers both the Linux (Deck) and Windows builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)