### PR TITLE
Persist the last browse folder immediately, not only at exit

### DIFF
--- a/GUI/src/mainwindow.cpp
+++ b/GUI/src/mainwindow.cpp
@@ -234,6 +234,13 @@ void MainWindow::browsePng(QLineEdit *edit, const QString &title)
     if (!fileName.isEmpty()) {
         edit->setText(fileName);
         lastBrowseDir = QFileInfo(fileName).absolutePath();
+        // Persist immediately rather than waiting for the destructor's
+        // writeSettings: on handhelds the app is often force-terminated
+        // (Steam/Xbox overlay, task switcher, suspend), which skips destructors.
+        QSettings settings(settingsPath, QSettings::IniFormat);
+        settings.beginGroup(QStringLiteral("Paths"));
+        settings.setValue(QStringLiteral("LastBrowseDir"), lastBrowseDir);
+        settings.endGroup();
     }
 }
 


### PR DESCRIPTION
## Summary
Same fix as jlobue10/rEFInd_GUI: `Paths/LastBrowseDir` was only written by the destructor's `writeSettings()`, which never runs when the app is force-terminated (Steam/Xbox overlay, task switcher, suspend) — so the remembered browse folder was lost between sessions on handhelds. Write the key immediately after each successful pick.

Verified end-to-end in the rEFInd_GUI twin repo on Windows 11 / Qt 6.11.1 (identical code path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)