### PR TITLE
Leave "Launch SteamDeck rEFInd GUI" unchecked by default after installation

### DIFF
--- a/Windows/GUI/SteamDeck_rEFInd.iss
+++ b/Windows/GUI/SteamDeck_rEFInd.iss
@@ -47,7 +47,8 @@ Name: "{autodesktop}\{#AppName}"; Filename: "{app}\{#AppExe}"; WorkingDir: "{app
 Name: "{app}\GUI\backgrounds"; Filename: "{app}\backgrounds"
 
 [Run]
-Filename: "{app}\{#AppExe}"; Description: "Launch {#AppName}"; Flags: nowait postinstall skipifsilent runascurrentuser
+; unchecked: don't launch the GUI by default when the installer finishes.
+Filename: "{app}\{#AppExe}"; Description: "Launch {#AppName}"; Flags: nowait postinstall skipifsilent runascurrentuser unchecked
 
 [UninstallRun]
 ; Undo the rEFInd boot entry and ESP files before the app files disappear.


### PR DESCRIPTION
The post-install launch checkbox in the Windows installer now defaults to unchecked (`unchecked` flag on the `[Run]` postinstall entry) — matching the sibling rEFInd_GUI repo. Takes effect in the next tagged release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)