### PR TITLE
Install base-devel in the pinned build root

### DIFF
--- a/.github/workflows/arch-release.yml
+++ b/.github/workflows/arch-release.yml
@@ -78,8 +78,10 @@ jobs:
             pacman -Syu --noconfirm
             # Exact makedepends from the PKGBUILD (plus git for the source
             # clone); makepkg then runs without -s, so a drifting PKGBUILD
-            # fails loudly here.
-            pacman -S --noconfirm --needed git cmake gcc glibc make qt6-base qt6-tools
+            # fails loudly here. base-devel is on top of that: makepkg needs
+            # fakeroot and debugedit, which the minimal bootstrap root does not
+            # ship and which PKGBUILDs conventionally assume rather than list.
+            pacman -S --noconfirm --needed base-devel git cmake gcc glibc make qt6-base qt6-tools
             pacman -Q glibc qt6-base gcc
             useradd -m builder
             chown -R builder: /work


### PR DESCRIPTION
Follow-up to #182. The v2.3.8 release build failed at the `makepkg` step:

```
==> ERROR: Cannot find the debugedit binary required for including source files in debug packages.
==> ERROR: Cannot find the fakeroot binary.
```

The bootstrap tarball is a *minimal* root, not `base-devel`. Both binaries come from the `base-devel` group, which PKGBUILDs conventionally assume is present rather than listing in `makedepends`.

The pinning itself worked — the run logged exactly the intended toolchain before failing:

```
glibc 2.41+r65+ge7c419a29575-1
qt6-base 6.9.1-5
gcc 15.1.1+r7+gf36ec88aa85a-1
```

After merge, re-run via `workflow_dispatch` against the existing `v2.3.8` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)