### PR TITLE
Make the Qt ABI guard fail closed

### DIFF
--- a/.github/workflows/arch-release.yml
+++ b/.github/workflows/arch-release.yml
@@ -93,11 +93,23 @@ jobs:
       # the pin before it reaches users.
       - name: Verify binary ABI is loadable on SteamOS
         run: |
+          set -euo pipefail
           pkg=$(ls *.pkg.tar.zst | grep -v -- '-debug-' | head -1)
-          mkdir -p verify && tar -C verify --use-compress-program=unzstd -xf "$pkg" usr/bin/SteamDeck_rEFInd
-          need=$(strings verify/usr/bin/SteamDeck_rEFInd | grep -oE '^Qt_6\.[0-9]+$' | sort -uV | tail -1)
-          echo "binary requires ${need:-none}; SteamOS supports up to Qt_${MAX_QT_ABI}"
-          if [ -n "$need" ] && [ "$(printf '%s\nQt_%s\n' "$need" "$MAX_QT_ABI" | sort -V | tail -1)" != "Qt_${MAX_QT_ABI}" ]; then
+          # makepkg chowns the workspace to the container's build user, so the
+          # runner cannot create directories here. Extract somewhere writable.
+          v="$RUNNER_TEMP/verify"; rm -rf "$v"; mkdir -p "$v"
+          tar -C "$v" --use-compress-program=unzstd -xf "$pkg" usr/bin/SteamDeck_rEFInd
+          bin="$v/usr/bin/SteamDeck_rEFInd"
+          [ -s "$bin" ] || { echo "::error::extracted binary is missing or empty; ABI check could not run."; exit 1; }
+          # Read the actual .gnu.version_r requirements rather than scraping
+          # strings, which silently yields nothing if the file is unreadable.
+          need=$(readelf -V "$bin" | grep -oE 'Qt_6\.[0-9]+' | sort -uV | tail -1 || true)
+          # Fail closed. A Qt Widgets binary always carries a Qt_6.x version
+          # node, so finding none means the check itself did not work — which
+          # is exactly how a broken build slipped through before.
+          [ -n "$need" ] || { echo "::error::no Qt version node found in the binary; ABI check did not run."; exit 1; }
+          echo "binary requires ${need}; SteamOS supports up to Qt_${MAX_QT_ABI}"
+          if [ "$(printf '%s\nQt_%s\n' "$need" "$MAX_QT_ABI" | sort -V | tail -1)" != "Qt_${MAX_QT_ABI}" ]; then
             echo "::error::Built binary requires ${need}, newer than SteamOS's Qt_${MAX_QT_ABI}; it would fail to start on every Deck. Check ARCH_SNAPSHOT."
             exit 1
           fi

--- a/scripts/build_GUI_pinned.sh
+++ b/scripts/build_GUI_pinned.sh
@@ -64,10 +64,17 @@ podman run --rm -v "$REPO_ROOT:/src:ro" -v "$OUT:/out" "$IMAGE" \
     "
 
 # The regression this script exists to prevent: a binary that cannot start on
-# a Deck. SteamOS 3.8.x tops out at Qt_6.9.
-NEED="$(strings "$OUT/SteamDeck_rEFInd" | grep -oE '^Qt_6\.[0-9]+$' | sort -uV | tail -1)"
-echo -e "\nBuilt $OUT/SteamDeck_rEFInd (requires ${NEED:-no versioned Qt symbols})"
-if [ -n "$NEED" ] && [ "$(printf '%s\nQt_6.9\n' "$NEED" | sort -V | tail -1)" != "Qt_6.9" ]; then
+# a Deck. SteamOS 3.8.x tops out at Qt_6.9. Read the real .gnu.version_r
+# requirements rather than scraping strings, and fail closed — a Qt Widgets
+# binary always carries a Qt_6.x version node, so finding none means the check
+# did not work rather than that the binary is clean.
+NEED="$(readelf -V "$OUT/SteamDeck_rEFInd" | grep -oE 'Qt_6\.[0-9]+' | sort -uV | tail -1 || true)"
+if [ -z "$NEED" ]; then
+    echo "Error: no Qt version node found in $OUT/SteamDeck_rEFInd; ABI check did not run." >&2
+    exit 1
+fi
+echo -e "\nBuilt $OUT/SteamDeck_rEFInd (requires $NEED)"
+if [ "$(printf '%s\nQt_6.9\n' "$NEED" | sort -V | tail -1)" != "Qt_6.9" ]; then
     echo "Error: binary requires $NEED, newer than SteamOS's Qt_6.9; it would not start." >&2
     exit 1
 fi


### PR DESCRIPTION
Follow-up to #182/#183. The ABI guard added in #182 **did not actually check anything** on the v2.3.8 run, and passed:

```
mkdir: cannot create directory 'verify': Permission denied
strings: 'verify/usr/bin/SteamDeck_rEFInd': No such file
binary requires none; SteamOS supports up to Qt_6.9
```

Two compounding bugs:

1. The `makepkg` step runs `chown -R builder: /work` inside the container, so the runner can no longer create directories in the workspace — extraction never happened.
2. The check was `[ -n "$need" ] && [ ... ]`, so an empty result (check couldn't run) was indistinguishable from a clean result and **passed**.

That is the same failure mode the guard exists to catch, so it needed to fail closed.

## Fixes

- Extract to `$RUNNER_TEMP` rather than the chowned workspace.
- Read `.gnu.version_r` via `readelf -V` instead of scraping `strings`, which silently yields nothing on an unreadable file.
- Error out when no `Qt_6.x` node is found at all — a Qt Widgets binary always has one.
- `set -euo pipefail` on the step.
- Same fail-open fix applied to `scripts/build_GUI_pinned.sh`.

## On v2.3.8 itself

The released artifact is **correct and unaffected**. Verified directly out of the published package:

```
$ objdump -p usr/bin/SteamDeck_rEFInd | grep -A2 'required from libQt6Core'
  required from libQt6Core.so.6:
    0x058a2919 0x00 14 Qt_6.9
```

Requires `Qt_6.9` / `GLIBC_2.34` — loadable on SteamOS 3.8.x. No re-release needed; this only restores the safety net for future builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)