### PR TITLE
Pair On/Off buttons on shared rows in the main window

### DIFF
--- a/GUI/src/mainwindow.ui
+++ b/GUI/src/mainwindow.ui
@@ -329,7 +329,7 @@
        </property>
       </widget>
      </item>
-     <item row="6" column="4" alignment="Qt::AlignRight">
+     <item row="8" column="4" alignment="Qt::AlignRight">
       <layout class="QHBoxLayout" name="horizontalLayout">
        <item alignment="Qt::AlignRight">
         <widget class="QLabel" name="Enable_Mouse_label">
@@ -350,7 +350,7 @@
        </item>
       </layout>
      </item>
-     <item row="6" column="5">
+     <item row="6" column="4" alignment="Qt::AlignRight">
       <widget class="QPushButton" name="Enable_sysd_pushButton">
        <property name="minimumSize">
         <size>
@@ -423,7 +423,7 @@
        </property>
       </widget>
      </item>
-     <item row="8" column="4" alignment="Qt::AlignRight">
+     <item row="8" column="5">
       <widget class="QPushButton" name="Open_Folder_pushButton">
        <property name="minimumSize">
         <size>
@@ -445,7 +445,7 @@
        </property>
       </widget>
      </item>
-     <item row="8" column="5">
+     <item row="6" column="5">
       <widget class="QPushButton" name="Disable_sysd_pushButton">
        <property name="minimumSize">
         <size>


### PR DESCRIPTION
Cosmetic layout rotation in `GUI/src/mainwindow.ui` so each button pair shares a row:

- **Sysd On** moves left into row 6, column 4 (right-aligned, matching Rand BG On above it)
- **Sysd Off** moves up into Sysd On's old spot (row 6, column 5)
- **Open Folder** moves into Sysd Off's old spot (row 8, column 5)
- **Enable Mouse** label+checkbox moves into Open Folder's old spot (row 8, column 4, right-aligned)

Resulting right-side rows: Rand BG On | Rand BG Off, Sysd On | Sysd Off, Enable Mouse | Open Folder.

No code changes — widget names, signals, and translations are untouched. Verified with `uic` and a full pinned-container build (`scripts/build_GUI_pinned.sh`, Qt_6.9 check passes).

Stacked on #196 (branched from its head since it reshapes the same file); GitHub will retarget to `main` when that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)