### PR TITLE
Seed new Windows assets without overwriting user files

### DIFF
--- a/GUI/src/platform.cpp
+++ b/GUI/src/platform.cpp
@@ -29,19 +29,33 @@ QString dataDir()
 
 static bool copySeedDir(const QString &source, const QString &destination)
 {
-    if (QFileInfo::exists(destination))
-        return true;
     const QDir sourceDir(source);
-    if (!sourceDir.exists() || !QDir().mkpath(destination))
+    const QFileInfo destinationInfo(destination);
+    if (!sourceDir.exists()
+        || (destinationInfo.exists() && !destinationInfo.isDir())
+        || !QDir().mkpath(destination)) {
         return false;
+    }
+
     for (const QFileInfo &entry : sourceDir.entryInfoList(
              QDir::Dirs | QDir::Files | QDir::NoDotAndDotDot)) {
         const QString target = destination + "/" + entry.fileName();
+        const QFileInfo targetInfo(target);
         if (entry.isDir()) {
+            if (targetInfo.exists() && !targetInfo.isDir())
+                return false;
             if (!copySeedDir(entry.filePath(), target))
                 return false;
-        } else if (!QFile::copy(entry.filePath(), target)) {
-            return false;
+        } else {
+            // Seed assets are defaults. Add files introduced by an update,
+            // but preserve every file the user already has.
+            if (targetInfo.exists()) {
+                if (!targetInfo.isFile())
+                    return false;
+                continue;
+            }
+            if (!QFile::copy(entry.filePath(), target))
+                return false;
         }
     }
     return true;


### PR DESCRIPTION
## Summary
- recurse into existing Windows data directories during startup
- seed newly shipped icons and backgrounds only when their destination files are absent
- preserve user-customized files and reject file/directory type conflicts

## Why
After the first launch, the previous early return prevented application updates from adding any newly bundled assets.

## Validation
- `git diff --check`
- reviewed missing, existing, nested, and type-conflict cases
- Qt/Windows build not run because the required toolchain is unavailable