### PR TITLE
Launch Windows system tools by absolute path

### DIFF
--- a/GUI/src/osdetect_win.cpp
+++ b/GUI/src/osdetect_win.cpp
@@ -1,4 +1,5 @@
 #include "osdetect.h"
+#include "platform.h"
 
 #include <QDir>
 #include <QJsonArray>
@@ -18,7 +19,14 @@ static QString runPowerShell(const QString &command, bool *ok = nullptr)
 {
     static const QString prologue =
         QStringLiteral("[Console]::OutputEncoding=[System.Text.Encoding]::UTF8;");
-    return OSDetector::runCommand(QStringLiteral("powershell.exe"),
+    const QString powershell = Platform::windowsSystemExecutable(
+        QStringLiteral("WindowsPowerShell/v1.0/powershell.exe"));
+    if (powershell.isEmpty()) {
+        if (ok)
+            *ok = false;
+        return {};
+    }
+    return OSDetector::runCommand(powershell,
                                   {QStringLiteral("-NoProfile"), QStringLiteral("-ExecutionPolicy"),
                                    QStringLiteral("Bypass"), QStringLiteral("-Command"),
                                    prologue + command},
@@ -92,6 +100,11 @@ QList<OSDetector::Partition> OSDetector::listPartitions()
     return partitions;
 }
 
+static QString mountvolPath()
+{
+    return Platform::windowsSystemExecutable(QStringLiteral("mountvol.exe"));
+}
+
 QString OSDetector::espScanRoot(const Partition &p, bool &release)
 {
     release = false;
@@ -106,7 +119,7 @@ QString OSDetector::espScanRoot(const Partition &p, bool &release)
             if (QDir(drive + "/").exists())
                 continue;
             bool ok = false;
-            runCommand(QStringLiteral("mountvol"), {drive, QStringLiteral("/S")}, &ok);
+            runCommand(mountvolPath(), {drive, QStringLiteral("/S")}, &ok);
             if (ok) {
                 release = true;
                 return drive;
@@ -123,7 +136,7 @@ QString OSDetector::espScanRoot(const Partition &p, bool &release)
             QDir::tempPath() + QStringLiteral("/refind-esp-scan-") + p.path);
         if (QDir().mkpath(dir)) {
             bool ok = false;
-            runCommand(QStringLiteral("mountvol"), {dir, p.volumePath}, &ok);
+            runCommand(mountvolPath(), {dir, p.volumePath}, &ok);
             if (ok) {
                 release = true;
                 return dir;
@@ -136,7 +149,7 @@ QString OSDetector::espScanRoot(const Partition &p, bool &release)
 
 void OSDetector::releaseEspRoot(const QString &root)
 {
-    runCommand(QStringLiteral("mountvol"), {root, QStringLiteral("/D")});
+    runCommand(mountvolPath(), {root, QStringLiteral("/D")});
     // Directory mount points (anything longer than "Z:") were created by
     // espScanRoot and are removed once unmounted.
     if (root.length() > 2)

--- a/GUI/src/platform.cpp
+++ b/GUI/src/platform.cpp
@@ -98,7 +98,7 @@ static QString trustedScriptPath(const QString &name)
     return {};
 }
 
-static QString systemPowerShell()
+QString windowsSystemExecutable(const QString &relativePath)
 {
     QString systemDirectory(MAX_PATH, Qt::Uninitialized);
     UINT length = GetSystemDirectoryW(
@@ -115,14 +115,15 @@ static QString systemPowerShell()
             return {};
     }
     systemDirectory.resize(static_cast<int>(length));
-    return QDir::toNativeSeparators(QDir::fromNativeSeparators(systemDirectory)
-                                    + "/WindowsPowerShell/v1.0/powershell.exe");
+    return QDir::toNativeSeparators(
+        QDir(QDir::fromNativeSeparators(systemDirectory)).filePath(relativePath));
 }
 
 static bool runScriptInWindow(const QString &scriptName, const QStringList &scriptArgs = {})
 {
     const QString scriptPath = trustedScriptPath(scriptName);
-    const QString powershell = systemPowerShell();
+    const QString powershell = windowsSystemExecutable(
+        QStringLiteral("WindowsPowerShell/v1.0/powershell.exe"));
     if (scriptPath.isEmpty() || powershell.isEmpty())
         return false;
     QStringList args = {QStringLiteral("-NoProfile"), QStringLiteral("-ExecutionPolicy"),
@@ -149,7 +150,8 @@ int installConfig(QString *output)
         args->flags |= CREATE_NO_WINDOW;
     });
     const QString script = trustedScriptPath(QStringLiteral("install_config_from_GUI.ps1"));
-    const QString powershell = systemPowerShell();
+    const QString powershell = windowsSystemExecutable(
+        QStringLiteral("WindowsPowerShell/v1.0/powershell.exe"));
     if (script.isEmpty() || powershell.isEmpty()) {
         if (output)
             *output = QCoreApplication::translate(

--- a/GUI/src/platform.h
+++ b/GUI/src/platform.h
@@ -14,6 +14,12 @@ namespace Platform {
 // %LOCALAPPDATA%\SteamDeck_rEFInd on Windows.
 QString dataDir();
 
+#ifdef Q_OS_WIN
+// Absolute path to a Windows executable below the protected system directory.
+// Callers must pass a trusted, application-defined relative path.
+QString windowsSystemExecutable(const QString &relativePath);
+#endif
+
 // Populate a new per-user data directory from the immutable files shipped next
 // to the executable. Existing user files are never overwritten.
 void prepareDataDir();


### PR DESCRIPTION
## Summary
- resolve PowerShell and `mountvol.exe` below the protected Windows system directory
- share one system-path resolver across platform and OS-detection code
- fail closed if the system directory cannot be resolved

## Security impact
The elevated GUI previously invoked bare executable names. A manipulated process search path could redirect those launches to an attacker-controlled binary.

## Validation
- `git diff --check`
- confirmed every OS-detection PowerShell/mountvol invocation now receives an absolute path
- Qt/Windows build not run because the required toolchain is unavailable