### PR TITLE
Select boot entries by Deck ESP and loader

### DIFF
--- a/GUI/src/mainwindow.cpp
+++ b/GUI/src/mainwindow.cpp
@@ -549,14 +549,55 @@ void MainWindow::on_Install_rEFInd_clicked()
 QString MainWindow::steamFirmwareBootNum()
 {
     bool ok = false;
-    const QString out = OSDetector::runCommand(QStringLiteral("efibootmgr"), {}, &ok);
+    const QString out = OSDetector::runCommand(
+        QStringLiteral("efibootmgr"), {QStringLiteral("-v")}, &ok);
     if (!ok)
         return {};
-    static const QRegularExpression re(QStringLiteral("^Boot([0-9A-Fa-f]{4})\\*?\\s+.*steam"),
-                                       QRegularExpression::CaseInsensitiveOption
-                                           | QRegularExpression::MultilineOption);
-    const QRegularExpressionMatch match = re.match(out);
-    return match.hasMatch() ? match.captured(1) : QString();
+
+    QStringList bootOrder;
+    static const QRegularExpression bootOrderRe(
+        QStringLiteral("^BootOrder:\\s*([0-9A-Fa-f]{4}(?:,[0-9A-Fa-f]{4})*)\\s*$"),
+        QRegularExpression::MultilineOption);
+    const QRegularExpressionMatch orderMatch = bootOrderRe.match(out);
+    if (orderMatch.hasMatch())
+        bootOrder = orderMatch.captured(1).toUpper().split(QLatin1Char(','));
+
+    QStringList loaderMatches;
+    QStringList labelMatches;
+    static const QRegularExpression entryRe(
+        QStringLiteral("^Boot([0-9A-Fa-f]{4})\\*?\\s+([^\\t\\r\\n]*)(?:\\t(.*))?$"));
+    static const QRegularExpression steamLoaderRe(
+        QStringLiteral("HD\\([^)]*\\)/(?:File\\()?\\\\EFI\\\\steamos\\\\steamcl\\.efi"
+                       "(?:\\)|[0-9A-Fa-f]{8}|$)"),
+        QRegularExpression::CaseInsensitiveOption);
+
+    const QStringList lines = out.split(QLatin1Char('\n'));
+    for (const QString &line : lines) {
+        const QRegularExpressionMatch entry = entryRe.match(line);
+        if (!entry.hasMatch())
+            continue;
+
+        const QString bootNum = entry.captured(1).toUpper();
+        const QString label = entry.captured(2).trimmed();
+        const QString devicePath = entry.captured(3).trimmed();
+        if (steamLoaderRe.match(devicePath).hasMatch())
+            loaderMatches.append(bootNum);
+        if (label.compare(QStringLiteral("SteamOS"), Qt::CaseInsensitive) == 0)
+            labelMatches.append(bootNum);
+    }
+
+    auto firstInBootOrder = [&bootOrder](const QStringList &candidates) {
+        for (const QString &bootNum : bootOrder) {
+            if (candidates.contains(bootNum))
+                return bootNum;
+        }
+        return candidates.value(0);
+    };
+
+    // The immutable loader path is authoritative. The exact label is only a
+    // compatibility fallback for firmware whose verbose path cannot be parsed.
+    const QString loaderMatch = firstInBootOrder(loaderMatches);
+    return loaderMatch.isEmpty() ? firstInBootOrder(labelMatches) : loaderMatch;
 }
 
 // These values are not user-typed: menuName/loaderPath come from ESP vendor

--- a/scripts/restore_EFI_entries.sh
+++ b/scripts/restore_EFI_entries.sh
@@ -15,29 +15,93 @@ if [ -z "$ESP_PARENT" ] && [ -n "$ESP_PART" ]; then
 	ESP_PARENT="$(basename "$(dirname "$(readlink -f "/sys/class/block/$ESP_PART")")")"
 fi
 ESP_DISK="/dev/$ESP_PARENT"
-if [ ! -b "$ESP_DISK" ] || [ -z "$ESP_PARTNUM" ]; then
+ESP_PARTUUID="$(lsblk -rno PARTUUID "$ESP_DEV" 2>/dev/null | head -1 | tr 'A-F' 'a-f')"
+if [ -z "$ESP_PARTUUID" ]; then
+	ESP_PARTUUID="$(blkid -s PARTUUID -o value "$ESP_DEV" 2>/dev/null | head -1 | tr 'A-F' 'a-f')"
+fi
+if [ ! -b "$ESP_DISK" ] || [ -z "$ESP_PARTNUM" ] || [ -z "$ESP_PARTUUID" ]; then
 	echo "ERROR: could not safely resolve the ESP's disk and partition from /esp; refusing to modify NVRAM." >&2
 	exit 1
 fi
 
-# efibootmgr >= 18 appends "\t<device path>" after the label even without -v,
-# so match on the start of the label rather than anchoring the whole line.
-if ! efibootmgr | grep -qE '^Boot[0-9A-Fa-f]{4}\*? +SteamOS'; then
-	# Recreate the missing SteamOS EFI entry
-	sudo efibootmgr -c -d "$ESP_DISK" -p "$ESP_PARTNUM" -L "SteamOS" -l '\EFI\steamos\steamcl.efi'
-fi
+TAB=$'\t'
+NVRAM_VERBOSE=""
+BOOT_ORDER=""
+refresh_nvram() {
+	NVRAM_VERBOSE="$(efibootmgr -v 2>/dev/null)" || {
+		echo "ERROR: efibootmgr could not read the firmware boot entries." >&2
+		return 1
+	}
+	BOOT_ORDER="$(printf '%s\n' "$NVRAM_VERBOSE" \
+		| sed -nE 's/^BootOrder:[[:space:]]*([0-9A-Fa-f,]+).*/\1/p' \
+		| head -1 | tr 'a-f' 'A-F')"
+}
 
-if ! efibootmgr | grep -qE '^Boot[0-9A-Fa-f]{4}\*? +rEFInd'; then
-	# Recreate the missing rEFInd EFI entry
-	sudo efibootmgr -c -d "$ESP_DISK" -p "$ESP_PARTNUM" -L "rEFInd" -l '\EFI\refind\refind_x64.efi'
-fi
+# Return every Boot#### ID whose actual device path targets this Deck ESP and
+# the requested loader. Labels are deliberately ignored: they are editable,
+# and a foreign/stale entry called rEFInd or SteamOS must not shadow this ESP.
+loader_entry_ids() {
+	local loader_re="$1"
+	printf '%s\n' "$NVRAM_VERBOSE" \
+		| grep -iE "^Boot[0-9A-Fa-f]{4}\\*?[[:space:]]+[^${TAB}]*${TAB}HD\\([0-9]+,GPT,${ESP_PARTUUID},[^)]*\\)/(File\\()?${loader_re}(\\)|[0-9A-Fa-f]{8}|$)" \
+		| sed -nE 's/^Boot([0-9A-Fa-f]{4}).*/\1/p' \
+		| tr 'a-f' 'A-F'
+}
 
-# Forcing rEFInd to have bootnext top priority, just in case Windows EFI entry is active
-REFIND_BOOTNUM="$(efibootmgr | sed -nE 's/^Boot([0-9A-Fa-f]{4})\*? +rEFInd.*/\1/p' | head -1)"
-if [ -n "$REFIND_BOOTNUM" ]; then
-	sudo efibootmgr -n "$REFIND_BOOTNUM"
-else
-	echo "Warning: no rEFInd entry found to set as next boot." >&2
-fi
+first_in_boot_order() {
+	local candidates="$1" id
+	for id in ${BOOT_ORDER//,/ }; do
+		if printf '%s\n' "$candidates" | grep -qx "$id"; then
+			printf '%s\n' "$id"
+			return 0
+		fi
+	done
+	printf '%s\n' "$candidates" | sed -n '1p'
+}
 
-echo -e "\nMissing EFI entries for SteamOS and/ or rEFInd have been restored.\n"
+find_loader_entry() {
+	local candidates
+	candidates="$(loader_entry_ids "$1")"
+	[ -n "$candidates" ] || return 1
+	first_in_boot_order "$candidates"
+}
+
+ENSURED_BOOTNUM=""
+ensure_loader_entry() {
+	local label="$1" loader_path="$2" loader_re="$3" loader_file="$4" bootnum
+	if [ ! -s "$loader_file" ]; then
+		echo "ERROR: $label loader is missing or empty at $loader_file; refusing to create a broken NVRAM entry." >&2
+		return 1
+	fi
+	bootnum="$(find_loader_entry "$loader_re")"
+	if [ -z "$bootnum" ]; then
+		echo "Creating the missing $label entry for the Deck ESP..." >&2
+		sudo efibootmgr -c -d "$ESP_DISK" -p "$ESP_PARTNUM" -L "$label" -l "$loader_path" >&2 \
+			|| return 1
+		refresh_nvram || return 1
+		bootnum="$(find_loader_entry "$loader_re")"
+		if [ -z "$bootnum" ]; then
+			echo "ERROR: the new $label entry could not be verified against the Deck ESP." >&2
+			return 1
+		fi
+	fi
+	if ! sudo efibootmgr -b "$bootnum" -a >/dev/null 2>&1; then
+		echo "ERROR: could not activate $label entry Boot$bootnum." >&2
+		return 1
+	fi
+	ENSURED_BOOTNUM="$bootnum"
+}
+
+refresh_nvram || exit 1
+ensure_loader_entry "SteamOS" '\EFI\steamos\steamcl.efi' \
+	'\\EFI\\steamos\\steamcl\.efi' /esp/efi/steamos/steamcl.efi || exit 1
+STEAMOS_BOOTNUM="$ENSURED_BOOTNUM"
+ensure_loader_entry "rEFInd" '\EFI\refind\refind_x64.efi' \
+	'\\EFI\\refind\\refind_x64\.efi' /esp/efi/refind/refind_x64.efi || exit 1
+REFIND_BOOTNUM="$ENSURED_BOOTNUM"
+
+# Force only the verified Deck-ESP rEFInd entry for the next boot.
+sudo efibootmgr -n "$REFIND_BOOTNUM" \
+	|| { echo "ERROR: could not set verified rEFInd entry Boot$REFIND_BOOTNUM as BootNext." >&2; exit 1; }
+
+echo -e "\nVerified SteamOS Boot$STEAMOS_BOOTNUM and rEFInd Boot$REFIND_BOOTNUM for the Deck ESP; BootNext is rEFInd.\n"

--- a/scripts/restore_EFI_entries.sh
+++ b/scripts/restore_EFI_entries.sh
@@ -40,10 +40,15 @@ refresh_nvram() {
 # Return every Boot#### ID whose actual device path targets this Deck ESP and
 # the requested loader. Labels are deliberately ignored: they are editable,
 # and a foreign/stale entry called rEFInd or SteamOS must not shadow this ESP.
+# HD( is matched anywhere after the label's tab, not anchored to it: entries
+# stored with a full device path (PciRoot(...)/Pci(...)/.../HD(...)) are just
+# as valid as the bare HD(...) form efibootmgr >= 18 prints, and anchoring
+# to the tab would make this script recreate (duplicate) such entries. This
+# mirrors the deliberately unanchored HD\( match in the GUI's C++ regex.
 loader_entry_ids() {
 	local loader_re="$1"
 	printf '%s\n' "$NVRAM_VERBOSE" \
-		| grep -iE "^Boot[0-9A-Fa-f]{4}\\*?[[:space:]]+[^${TAB}]*${TAB}HD\\([0-9]+,GPT,${ESP_PARTUUID},[^)]*\\)/(File\\()?${loader_re}(\\)|[0-9A-Fa-f]{8}|$)" \
+		| grep -iE "^Boot[0-9A-Fa-f]{4}\\*?[[:space:]]+[^${TAB}]*${TAB}.*HD\\([0-9]+,GPT,${ESP_PARTUUID},[^)]*\\)/(File\\()?${loader_re}(\\)|[0-9A-Fa-f]{8}|$)" \
 		| sed -nE 's/^Boot([0-9A-Fa-f]{4}).*/\1/p' \
 		| tr 'a-f' 'A-F'
 }
@@ -66,22 +71,74 @@ find_loader_entry() {
 	first_in_boot_order "$candidates"
 }
 
-ENSURED_BOOTNUM=""
-ensure_loader_entry() {
-	local label="$1" loader_path="$2" loader_re="$3" loader_file="$4" bootnum
-	if [ ! -s "$loader_file" ]; then
-		echo "ERROR: $label loader is missing or empty at $loader_file; refusing to create a broken NVRAM entry." >&2
-		return 1
+# Fallback for rEFInd only: rEFInd may legitimately live on an SD card or the
+# Windows ESP rather than the Deck ESP (the pre-UUID-matching script supported
+# that via its label match). If no entry matches the Deck ESP, accept an
+# ACTIVE entry (the * is mandatory here) whose loader path ends in
+# \EFI\refind\refind_x64.efi on ANY HD( partition, preferring one listed in
+# BootOrder. Such an entry is only USED for BootNext; it is never created,
+# deleted, activated, or otherwise modified.
+find_refind_fallback_entry() {
+	local candidates
+	candidates="$(printf '%s\n' "$NVRAM_VERBOSE" \
+		| grep -iE "^Boot[0-9A-Fa-f]{4}\\*[[:space:]]+[^${TAB}]*${TAB}.*HD\\([0-9]+,GPT,[0-9A-Fa-f-]+,[^)]*\\)/(File\\()?\\\\EFI\\\\refind\\\\refind_x64\\.efi(\\)|[0-9A-Fa-f]{8}|$)" \
+		| sed -nE 's/^Boot([0-9A-Fa-f]{4}).*/\1/p' \
+		| tr 'a-f' 'A-F')"
+	[ -n "$candidates" ] || return 1
+	first_in_boot_order "$candidates"
+}
+
+# Best-effort cleanup after a create that could not be re-verified (e.g. a
+# future efibootmgr output format the matcher does not understand): find the
+# entry that did not exist before the create and carries the exact label, and
+# delete it. Without this the boot-time unit would add one duplicate entry
+# per boot, forever; with it the failure is self-limiting.
+delete_unverified_entry() {
+	local label="$1" pre_ids="$2" id
+	id="$(printf '%s\n' "$NVRAM_VERBOSE" \
+		| grep -E "^Boot[0-9A-Fa-f]{4}\\*?[[:space:]]+${label}(${TAB}|$)" \
+		| sed -nE 's/^Boot([0-9A-Fa-f]{4}).*/\1/p' \
+		| tr 'a-f' 'A-F' \
+		| grep -vxF -f <(printf '%s\n' "$pre_ids") \
+		| tail -1)"
+	if [ -n "$id" ]; then
+		echo "Deleting the unverifiable new $label entry Boot$id so repeated runs cannot pile up duplicates." >&2
+		sudo efibootmgr -b "$id" -B >/dev/null 2>&1
 	fi
+}
+
+ENSURED_BOOTNUM=""
+ENSURED_VIA_FALLBACK=0
+ensure_loader_entry() {
+	local label="$1" loader_path="$2" loader_re="$3" loader_file="$4" fallback_fn="${5:-}" bootnum pre_ids
+	ENSURED_VIA_FALLBACK=0
 	bootnum="$(find_loader_entry "$loader_re")"
+	if [ -z "$bootnum" ] && [ -n "$fallback_fn" ]; then
+		if bootnum="$("$fallback_fn")" && [ -n "$bootnum" ]; then
+			echo "NOTE: no $label entry matches the Deck ESP; using existing non-Deck-ESP $label entry Boot$bootnum (e.g. SD card or Windows ESP) for BootNext without modifying it." >&2
+			ENSURED_BOOTNUM="$bootnum"
+			ENSURED_VIA_FALLBACK=1
+			return 0
+		fi
+		bootnum=""
+	fi
 	if [ -z "$bootnum" ]; then
+		# sudo: SteamOS mounts ESPs 0700 root:root, so an unprivileged test
+		# (e.g. the documented manual recovery run as deck) cannot see the
+		# loader and would wrongly report it missing.
+		if ! sudo test -s "$loader_file"; then
+			echo "ERROR: $label loader is missing or empty at $loader_file; refusing to create a broken NVRAM entry." >&2
+			return 1
+		fi
 		echo "Creating the missing $label entry for the Deck ESP..." >&2
+		pre_ids="$(printf '%s\n' "$NVRAM_VERBOSE" | sed -nE 's/^Boot([0-9A-Fa-f]{4}).*/\1/p' | tr 'a-f' 'A-F')"
 		sudo efibootmgr -c -d "$ESP_DISK" -p "$ESP_PARTNUM" -L "$label" -l "$loader_path" >&2 \
 			|| return 1
 		refresh_nvram || return 1
 		bootnum="$(find_loader_entry "$loader_re")"
 		if [ -z "$bootnum" ]; then
 			echo "ERROR: the new $label entry could not be verified against the Deck ESP." >&2
+			delete_unverified_entry "$label" "$pre_ids"
 			return 1
 		fi
 	fi
@@ -93,15 +150,29 @@ ensure_loader_entry() {
 }
 
 refresh_nvram || exit 1
-ensure_loader_entry "SteamOS" '\EFI\steamos\steamcl.efi' \
-	'\\EFI\\steamos\\steamcl\.efi' /esp/efi/steamos/steamcl.efi || exit 1
-STEAMOS_BOOTNUM="$ENSURED_BOOTNUM"
-ensure_loader_entry "rEFInd" '\EFI\refind\refind_x64.efi' \
-	'\\EFI\\refind\\refind_x64\.efi' /esp/efi/refind/refind_x64.efi || exit 1
-REFIND_BOOTNUM="$ENSURED_BOOTNUM"
 
-# Force only the verified Deck-ESP rEFInd entry for the next boot.
+# A SteamOS-side failure must not block restoring rEFInd or setting BootNext:
+# warn and carry on. Only a rEFInd-side failure prevents BootNext below.
+STEAMOS_BOOTNUM=""
+if ensure_loader_entry "SteamOS" '\EFI\steamos\steamcl.efi' \
+	'\\EFI\\steamos\\steamcl\.efi' /esp/efi/steamos/steamcl.efi; then
+	STEAMOS_BOOTNUM="$ENSURED_BOOTNUM"
+else
+	echo "WARNING: could not verify or restore the SteamOS entry; continuing with rEFInd and BootNext anyway." >&2
+fi
+
+ensure_loader_entry "rEFInd" '\EFI\refind\refind_x64.efi' \
+	'\\EFI\\refind\\refind_x64\.efi' /esp/efi/refind/refind_x64.efi \
+	find_refind_fallback_entry || exit 1
+REFIND_BOOTNUM="$ENSURED_BOOTNUM"
+REFIND_VIA_FALLBACK="$ENSURED_VIA_FALLBACK"
+
+# Force only the verified rEFInd entry for the next boot.
 sudo efibootmgr -n "$REFIND_BOOTNUM" \
 	|| { echo "ERROR: could not set verified rEFInd entry Boot$REFIND_BOOTNUM as BootNext." >&2; exit 1; }
 
-echo -e "\nVerified SteamOS Boot$STEAMOS_BOOTNUM and rEFInd Boot$REFIND_BOOTNUM for the Deck ESP; BootNext is rEFInd.\n"
+STEAMOS_MSG="SteamOS Boot$STEAMOS_BOOTNUM"
+[ -n "$STEAMOS_BOOTNUM" ] || STEAMOS_MSG="SteamOS (NOT verified, see warning above)"
+REFIND_MSG="rEFInd Boot$REFIND_BOOTNUM for the Deck ESP"
+[ "$REFIND_VIA_FALLBACK" = 0 ] || REFIND_MSG="rEFInd Boot$REFIND_BOOTNUM on a non-Deck-ESP partition"
+echo -e "\nVerified $STEAMOS_MSG and $REFIND_MSG; BootNext is rEFInd.\n"


### PR DESCRIPTION
## Summary
- make the GUI prefer the exact SteamOS loader path and firmware `BootOrder`
- make the bootnext service resolve the Deck ESP's partition UUID
- match SteamOS/rEFInd entries by partition UUID plus exact loader path, not editable labels
- recreate and read back missing entries, require non-empty loaders, activate verified entries, and set BootNext only to the verified Deck rEFInd entry

## Why
A foreign or stale entry whose label merely contained `SteamOS` or `rEFInd` could suppress recreation and receive `firmware_bootnum`/BootNext, sending the machine to the wrong disk or a dead loader.

## Validation
- `bash -n scripts/restore_EFI_entries.sh`
- `git diff --check`
- exercised the verbose-entry matcher with valid, foreign-partition, and label-only samples
- Qt and live NVRAM tests were unavailable in this environment

## Review fixes (commit 6e56171)

All in `scripts/restore_EFI_entries.sh`; the GUI half was reviewed clean and is untouched.

1. **Loader check now runs via sudo** — SteamOS mounts ESPs 0700 root:root, so the unprivileged `[ -s ]` always failed ("loader is missing or empty") when the documented manual recovery flow runs this script as `deck`. Now `sudo test -s`, guarding only the entry-create branch (matching its "refusing to create" purpose).
2. **SteamOS failure decoupled from rEFInd/BootNext** — a SteamOS-side failure warns on stderr but the script still attempts the rEFInd ensure and BootNext; only a rEFInd-side failure prevents BootNext.
3. **Matcher anchor relaxed** — `\tHD(` became `\t.*HD(` so valid entries stored with a full `PciRoot(...)/.../HD(...)` device path are matched rather than duplicated, mirroring the GUI's unanchored `HD\(` regex.
4. **Duplicate-entry guard** — if a just-created entry fails the verify re-find (future efibootmgr format drift), the script best-effort deletes it (exact label + not in the pre-create bootnum snapshot) before failing, so the boot-time unit can no longer add one duplicate entry per boot forever.
5. **Different-ESP BootNext fallback (please sign off)** — new behavior: if NO rEFInd entry matches the Deck ESP, an ACTIVE entry whose loader path ends in `\EFI\refind\refind_x64.efi` (case-insensitive) on ANY `HD(` partition — preferring one listed in BootOrder — is used for `efibootmgr -n` BootNext only, with a stderr note. It is never created, deleted, activated, or modified. This restores the pre-PR support for rEFInd living on an SD card or the Windows ESP without recreating anything blindly; only if neither primary nor fallback matches does the create-on-Deck-ESP path run.

Fixture harness (extracted matchers + synthetic `efibootmgr -v` samples): bare `HD(` (efibootmgr >= 18), legacy `/File(...)`, full `PciRoot(...)` prefix, uppercase variants, inactive entries, optional-data suffixes; rejects foreign-partition clones and label-only lookalikes — 14/14 pass. `bash -n` clean.
