### PR TITLE
Install staged ESP config transactionally

### DIFF
--- a/Windows/GUI/install_config_from_GUI.ps1
+++ b/Windows/GUI/install_config_from_GUI.ps1
@@ -103,27 +103,53 @@ if (-not $mount) {
     $mount = Mount-EspPartition $system
 }
 
+$staged = @{}
+$stagePaths = @()
 try {
     $src = Join-Path $env:LOCALAPPDATA 'SteamDeck_rEFInd\GUI'
     $dest = Join-Path $mount.Root 'EFI\refind'
     New-Item -ItemType Directory -Force $dest | Out-Null
-    # Keep one rollback copy of the live config before overwriting it.
-    $liveConf = Join-Path $dest 'refind.conf'
-    if (Test-Path $liveConf) {
-        Copy-Item -Force $liveConf (Join-Path $dest 'refind.conf.prev')
+
+    $sourceConf = Join-Path $src 'refind.conf'
+    if (-not (Test-Path -LiteralPath $sourceConf -PathType Leaf) -or
+        (Get-Item -LiteralPath $sourceConf).Length -le 0) {
+        throw "No non-empty refind.conf was found in $src. Use Create Config in the GUI first."
     }
-    $copied = 0
+
     foreach ($f in 'refind.conf','background.png','os_icon1.png','os_icon2.png','os_icon3.png','os_icon4.png') {
-        $p = Join-Path $src $f
-        if (Test-Path $p) {
-            Copy-Item -Force $p (Join-Path $dest $f)
-            Write-Host "Installed $f"
-            $copied++
+        $source = Join-Path $src $f
+        if (-not (Test-Path -LiteralPath $source -PathType Leaf)) { continue }
+
+        $stage = Join-Path $dest ('.' + $f + '.new.' + [guid]::NewGuid().ToString('N'))
+        $stagePaths += $stage
+        Copy-Item -LiteralPath $source -Destination $stage
+        if ($f -eq 'refind.conf' -and (Get-Item -LiteralPath $stage).Length -le 0) {
+            throw 'The staged refind.conf is empty; the live config was not changed.'
         }
+        $staged[$f] = $stage
     }
-    if ($copied -eq 0) {
-        throw "No config files were found in $src. Use Create Config in the GUI first."
+    if (-not $staged.ContainsKey('refind.conf')) {
+        throw 'refind.conf disappeared while it was being staged; the live config was not changed.'
     }
+
+    # Keep one rollback copy of the live config through a same-directory stage.
+    $liveConf = Join-Path $dest 'refind.conf'
+    if (Test-Path -LiteralPath $liveConf -PathType Leaf) {
+        $backupStage = Join-Path $dest ('.refind.conf.prev.new.' + [guid]::NewGuid().ToString('N'))
+        $stagePaths += $backupStage
+        Copy-Item -LiteralPath $liveConf -Destination $backupStage
+        Move-Item -Force -LiteralPath $backupStage -Destination (Join-Path $dest 'refind.conf.prev')
+    }
+
+    # Publish optional assets first and refind.conf last.
+    foreach ($f in 'background.png','os_icon1.png','os_icon2.png','os_icon3.png','os_icon4.png') {
+        if (-not $staged.ContainsKey($f)) { continue }
+        Move-Item -Force -LiteralPath $staged[$f] -Destination (Join-Path $dest $f)
+        Write-Host "Installed $f"
+    }
+    Move-Item -Force -LiteralPath $staged['refind.conf'] -Destination $liveConf
+    Write-Host 'Installed refind.conf'
+
     # A temp access-path mount's directory name means nothing to the user, so
     # describe that ESP by disk/partition instead.
     $where = if ($mount.Kind -eq 'accesspath') {
@@ -133,5 +159,8 @@ try {
     }
     Write-Host "Config installed to $where"
 } finally {
+    foreach ($stage in $stagePaths) {
+        Remove-Item -Force -LiteralPath $stage -ErrorAction SilentlyContinue
+    }
     Dismount-Esp $mount
 }

--- a/Windows/GUI/install_config_from_GUI.ps1
+++ b/Windows/GUI/install_config_from_GUI.ps1
@@ -110,6 +110,16 @@ try {
     $dest = Join-Path $mount.Root 'EFI\refind'
     New-Item -ItemType Directory -Force $dest | Out-Null
 
+    # Best-effort sweep of staging files left behind by an earlier interrupted
+    # run (the finally block cannot run across a kill or power loss, and every
+    # run mints new random staging names, so leftovers would otherwise
+    # accumulate on the small ESP). Only the exact ".<name>.new.<suffix>"
+    # shapes created below are matched, so no live file can be touched.
+    foreach ($f in 'refind.conf','background.png','os_icon1.png','os_icon2.png','os_icon3.png','os_icon4.png','refind.conf.prev') {
+        Get-ChildItem -LiteralPath $dest -Filter ".$f.new.*" -File -ErrorAction SilentlyContinue |
+            Remove-Item -Force -ErrorAction SilentlyContinue
+    }
+
     $sourceConf = Join-Path $src 'refind.conf'
     if (-not (Test-Path -LiteralPath $sourceConf -PathType Leaf) -or
         (Get-Item -LiteralPath $sourceConf).Length -le 0) {
@@ -141,7 +151,9 @@ try {
         Move-Item -Force -LiteralPath $backupStage -Destination (Join-Path $dest 'refind.conf.prev')
     }
 
-    # Publish optional assets first and refind.conf last.
+    # Staged, publish-last: optional assets first and refind.conf last (an
+    # overwriting Move-Item is delete-then-move, not an atomic swap, hence the
+    # config is published last).
     foreach ($f in 'background.png','os_icon1.png','os_icon2.png','os_icon3.png','os_icon4.png') {
         if (-not $staged.ContainsKey($f)) { continue }
         Move-Item -Force -LiteralPath $staged[$f] -Destination (Join-Path $dest $f)

--- a/scripts/install_config_from_GUI.sh
+++ b/scripts/install_config_from_GUI.sh
@@ -28,7 +28,15 @@ FILES="$3"
 
 # shellcheck source=/dev/null
 . "$LIB" || { echo "ERR_NOLIB $LIB"; exit 7; }
-trap esp_cleanup EXIT
+STAGED_FILES=()
+cleanup() {
+    local staged
+    for staged in "${STAGED_FILES[@]}"; do
+        [ -n "$staged" ] && rm -f -- "$staged" 2>/dev/null
+    done
+    esp_cleanup
+}
+trap cleanup EXIT
 
 RESOLVED="$(resolve_refind_dir)" || { echo "ERR_NOTARGET"; exit 3; }
 TARGET="${RESOLVED%%|*}"
@@ -38,16 +46,43 @@ esp_make_writable "$TARGET"
 
 mkdir -p "$TARGET" 2>/dev/null || { echo "ERR_MKDIR $TARGET"; exit 4; }
 
-# Keep one rollback copy of the live config before overwriting it.
-[ -f "$TARGET/refind.conf" ] && cp -f "$TARGET/refind.conf" "$TARGET/refind.conf.prev" 2>/dev/null
+[ -f "$SRC/refind.conf" ] && [ -s "$SRC/refind.conf" ] \
+    || { echo "ERR_NOSRC"; exit 6; }
 
 COPIED=0
+declare -A STAGED
 for f in $FILES; do
     [ -f "$SRC/$f" ] || continue
-    cp -f "$SRC/$f" "$TARGET/" 2>/dev/null || { echo "ERR_COPY $f"; exit 5; }
+    stage="$(mktemp "$TARGET/.${f}.new.XXXXXX")" \
+        || { echo "ERR_COPY $f"; exit 5; }
+    STAGED["$f"]="$stage"
+    STAGED_FILES+=("$stage")
+    cp -f -- "$SRC/$f" "$stage" 2>/dev/null \
+        || { echo "ERR_COPY $f"; exit 5; }
+    if [ "$f" = refind.conf ] && [ ! -s "$stage" ]; then
+        echo "ERR_COPY $f"
+        exit 5
+    fi
     COPIED=$((COPIED + 1))
 done
-[ "$COPIED" -gt 0 ] || { echo "ERR_NOSRC"; exit 6; }
+[ -n "${STAGED[refind.conf]:-}" ] || { echo "ERR_NOSRC"; exit 6; }
+
+if [ -f "$TARGET/refind.conf" ]; then
+    backup_stage="$(mktemp "$TARGET/.refind.conf.prev.new.XXXXXX")" \
+        || { echo "ERR_COPY refind.conf.prev"; exit 5; }
+    STAGED_FILES+=("$backup_stage")
+    cp -- "$TARGET/refind.conf" "$backup_stage" 2>/dev/null \
+        && mv -f -- "$backup_stage" "$TARGET/refind.conf.prev" 2>/dev/null \
+        || { echo "ERR_COPY refind.conf.prev"; exit 5; }
+fi
+
+for f in background.png os_icon1.png os_icon2.png os_icon3.png os_icon4.png; do
+    [ -n "${STAGED[$f]:-}" ] || continue
+    mv -f -- "${STAGED[$f]}" "$TARGET/$f" 2>/dev/null \
+        || { echo "ERR_COPY $f"; exit 5; }
+done
+mv -f -- "${STAGED[refind.conf]}" "$TARGET/refind.conf" 2>/dev/null \
+    || { echo "ERR_COPY refind.conf"; exit 5; }
 
 # Flush to the ESP before the temporary mount (if any) goes away.
 sync
@@ -74,7 +109,7 @@ else
         3) MSG="$(printf "No EFI System Partition with rEFInd on it could be found,\nand no system ESP is mounted.\n\nInstall rEFInd first, then install the config.")" ;;
         4) MSG="$(printf "Could not create the destination directory:\n%s\n\nThe EFI System Partition may be mounted read-only." "${RESULT#ERR_MKDIR }")" ;;
         5) MSG="$(printf "Failed while copying %s to the EFI System Partition.\n\nIt may be full or mounted read-only." "${RESULT#ERR_COPY }")" ;;
-        6) MSG="$(printf "None of the config files were found in:\n%s\n\nGenerate the config in the GUI first (Create Config)." "$SRC")" ;;
+        6) MSG="$(printf "No non-empty refind.conf was found in:\n%s\n\nGenerate the config in the GUI first (Create Config)." "$SRC")" ;;
         7) MSG="$(printf "Could not load the ESP resolution helper:\n%s\n\nRe-run the GUI installer to restore it." "${RESULT#ERR_NOLIB }")" ;;
         *) MSG="$(printf "Incorrect sudo password, or the prompt was cancelled.\n\nPlease try again providing the correct sudo password.")" ;;
     esac

--- a/scripts/install_config_from_GUI.sh
+++ b/scripts/install_config_from_GUI.sh
@@ -46,6 +46,16 @@ esp_make_writable "$TARGET"
 
 mkdir -p "$TARGET" 2>/dev/null || { echo "ERR_MKDIR $TARGET"; exit 4; }
 
+# Best-effort sweep of staging leftovers from an earlier interrupted run (the
+# EXIT trap cannot run across SIGKILL or power loss, and random staging names
+# would accumulate on the small ESP). Only the ".<name>.new.<suffix>" shapes
+# created below are matched, so no live file can be touched.
+for f in $FILES refind.conf.prev; do
+    for stale in "$TARGET/.$f.new."*; do
+        [ -f "$stale" ] && rm -f -- "$stale" 2>/dev/null
+    done
+done
+
 [ -f "$SRC/refind.conf" ] && [ -s "$SRC/refind.conf" ] \
     || { echo "ERR_NOSRC"; exit 6; }
 
@@ -76,7 +86,10 @@ if [ -f "$TARGET/refind.conf" ]; then
         || { echo "ERR_COPY refind.conf.prev"; exit 5; }
 fi
 
-for f in background.png os_icon1.png os_icon2.png os_icon3.png os_icon4.png; do
+# Staged, publish-last: assets first, refind.conf last. Publishing walks the
+# same $FILES list as staging, so the two loops cannot drift apart.
+for f in $FILES; do
+    [ "$f" = refind.conf ] && continue
     [ -n "${STAGED[$f]:-}" ] || continue
     mv -f -- "${STAGED[$f]}" "$TARGET/$f" 2>/dev/null \
         || { echo "ERR_COPY $f"; exit 5; }

--- a/scripts/install_config_from_GUI_root.sh
+++ b/scripts/install_config_from_GUI_root.sh
@@ -208,6 +208,17 @@ mkdir -p "$TARGET" 2> /dev/null || {
     exit 4
 }
 
+# Best-effort sweep of staging files left behind by an earlier interrupted run
+# (the EXIT trap cannot run across SIGKILL or power loss, and every run mints
+# new random staging names, so leftovers would otherwise accumulate on the
+# small ESP). Only the exact ".<name>.new.<suffix>" shapes created below are
+# matched, so no live file can be touched.
+for f in $FILES refind.conf.prev; do
+    for stale in "$TARGET/.$f.new."*; do
+        [ -f "$stale" ] && rm -f -- "$stale" 2> /dev/null
+    done
+done
+
 # A config is mandatory. Images are optional, but images alone must not count
 # as a successful installation.
 if ! runuser -u "$RUN_USER" -- test -f "$SRC/refind.conf" 2> /dev/null \
@@ -262,9 +273,12 @@ if [ -f "$TARGET/refind.conf" ]; then
     fi
 fi
 
-# Publish assets first and refind.conf last. All renames remain on the ESP, so
-# failed source or destination writes cannot truncate existing live files.
-for f in background.png os_icon1.png os_icon2.png os_icon3.png os_icon4.png; do
+# Publish assets first and refind.conf last (staged, publish-last: the renames
+# remain on the ESP, so failed source or destination writes cannot truncate
+# existing live files). Everything staged from $FILES is published here, so the
+# two loops cannot drift apart.
+for f in $FILES; do
+    [ "$f" = refind.conf ] && continue
     [ -n "${STAGED[$f]:-}" ] || continue
     if ! mv -f -- "${STAGED[$f]}" "$TARGET/$f" 2> /dev/null; then
         echo "Failed while publishing $f; the live config was not changed."

--- a/scripts/install_config_from_GUI_root.sh
+++ b/scripts/install_config_from_GUI_root.sh
@@ -51,9 +51,13 @@ ESP_TYPE_GUID=c12a7328-f81f-11d2-ba4b-00a0c93ec93b
 # a subshell — an array assignment there would be lost to the parent and the
 # EXIT trap would unmount nothing, leaving removable ESPs mounted read-write.
 ESP_TMPMNT_LIST="$(mktemp)"
+STAGED_FILES=()
 
 esp_cleanup() {
-    local m
+    local m staged
+    for staged in "${STAGED_FILES[@]}"; do
+        [ -n "$staged" ] && rm -f -- "$staged" 2> /dev/null
+    done
     if [ -n "${ESP_TMPMNT_LIST:-}" ] && [ -f "$ESP_TMPMNT_LIST" ]; then
         while read -r m; do
             [ -n "$m" ] || continue
@@ -204,10 +208,17 @@ mkdir -p "$TARGET" 2> /dev/null || {
     exit 4
 }
 
-# Keep one rollback copy of the live config before overwriting it.
-[ -f "$TARGET/refind.conf" ] && cp -f "$TARGET/refind.conf" "$TARGET/refind.conf.prev" 2>/dev/null
+# A config is mandatory. Images are optional, but images alone must not count
+# as a successful installation.
+if ! runuser -u "$RUN_USER" -- test -f "$SRC/refind.conf" 2> /dev/null \
+    || ! runuser -u "$RUN_USER" -- test -s "$SRC/refind.conf" 2> /dev/null; then
+    echo "No non-empty refind.conf was found in $SRC."
+    echo "Use Create Config in the GUI first."
+    exit 6
+fi
 
 COPIED=0
+declare -A STAGED
 for f in $FILES; do
     # Existence check AND content read both run as the invoking user, never as
     # root: this script is reachable without a password, so reading the source
@@ -215,18 +226,54 @@ for f in $FILES; do
     # exfiltrate any root-readable file onto the (world-readable when
     # temp-mounted) ESP. runuser can only read what the user can.
     runuser -u "$RUN_USER" -- test -f "$SRC/$f" 2> /dev/null || continue
-    if ! runuser -u "$RUN_USER" -- cat -- "$SRC/$f" > "$TARGET/$f" 2> /dev/null; then
-        rm -f "$TARGET/$f" 2> /dev/null
+    stage="$(mktemp "$TARGET/.${f}.new.XXXXXX")" || {
+        echo "Could not create a staging file in $TARGET -- the ESP may be full or read-only."
+        exit 5
+    }
+    STAGED["$f"]="$stage"
+    STAGED_FILES+=("$stage")
+    if ! runuser -u "$RUN_USER" -- cat -- "$SRC/$f" > "$stage" 2> /dev/null; then
         echo "Failed while copying $f to $TARGET -- the ESP may be full or read-only."
+        exit 5
+    fi
+    if [ "$f" = refind.conf ] && [ ! -s "$stage" ]; then
+        echo "The staged refind.conf is empty; the live config was not changed."
         exit 5
     fi
     COPIED=$((COPIED + 1))
 done
 
-if [ "$COPIED" -eq 0 ]; then
-    echo "No config files were found in $SRC."
-    echo "Use Create Config in the GUI first."
+if [ -z "${STAGED[refind.conf]:-}" ]; then
+    echo "refind.conf disappeared while it was being staged; the live config was not changed."
     exit 6
+fi
+
+# Preserve the rollback config through its own same-directory staging file.
+if [ -f "$TARGET/refind.conf" ]; then
+    backup_stage="$(mktemp "$TARGET/.refind.conf.prev.new.XXXXXX")" || {
+        echo "Could not stage the rollback copy in $TARGET."
+        exit 5
+    }
+    STAGED_FILES+=("$backup_stage")
+    if ! cp -- "$TARGET/refind.conf" "$backup_stage" 2> /dev/null \
+        || ! mv -f -- "$backup_stage" "$TARGET/refind.conf.prev" 2> /dev/null; then
+        echo "Could not preserve the previous refind.conf; the live config was not changed."
+        exit 5
+    fi
+fi
+
+# Publish assets first and refind.conf last. All renames remain on the ESP, so
+# failed source or destination writes cannot truncate existing live files.
+for f in background.png os_icon1.png os_icon2.png os_icon3.png os_icon4.png; do
+    [ -n "${STAGED[$f]:-}" ] || continue
+    if ! mv -f -- "${STAGED[$f]}" "$TARGET/$f" 2> /dev/null; then
+        echo "Failed while publishing $f; the live config was not changed."
+        exit 5
+    fi
+done
+if ! mv -f -- "${STAGED[refind.conf]}" "$TARGET/refind.conf" 2> /dev/null; then
+    echo "Failed while publishing refind.conf; the previous config is still active."
+    exit 5
 fi
 
 # Flush to the ESP before any temporary mount goes away.


### PR DESCRIPTION
## Summary
- keep the passwordless helper self-contained and root-owned under persistent `/etc/SteamDeck_rEFInd`
- require a regular, non-empty `refind.conf` before modifying live ESP files
- stage all available inputs beside their destinations and clean them on exit
- build the rollback config through a staged replacement
- publish optional images first and `refind.conf` last on Linux and Windows

Note on the title: the scheme is staged, publish-last rather than truly transactional/atomic — FAT32 offers no rename atomicity across power loss, and an overwriting `Move-Item -Force` is delete-then-move. Ordering the config publish last is what protects the live config.

## Why
Direct copies began with the live config, so a full/read-only ESP or short copy could truncate it. Images alone also counted as a successful config install.

## Validation
- `bash -n scripts/install_config_from_GUI_root.sh scripts/install_config_from_GUI.sh`
- `git diff --check`
- reviewed NOPASSWD source reads to ensure they still run as the invoking user
- PowerShell/live ESP execution was unavailable in this environment

## Review fixes
Follow-up commit addressing review feedback:
- The publish loops in both bash helpers now walk the same `$FILES` list the staging loop uses (skipping `refind.conf`, which is still published last), so a future `FILES` addition can no longer be staged, counted as copied, then silently discarded by cleanup while being reported installed.
- All three helpers now sweep staging leftovers from earlier interrupted runs right after the target directory is ensured — traps/`finally` cannot run across SIGKILL or power loss, and each run mints new random staging names, so leftovers would otherwise accumulate on the small ESP. The sweep matches only the exact `.<name>.new.<suffix>` shapes these helpers create, never live files.
- Comments now describe the scheme as staged, publish-last instead of implying atomicity.
- Validation: `bash -n`, PS 5.1 `Parser::ParseFile` (no errors), and a smoke test confirming the sweep deletes only stale staging files.
