### PR TITLE
Restore SteamOS read-only mode on every exit

### DIFF
--- a/SteamDeck_rEFInd_install.sh
+++ b/SteamDeck_rEFInd_install.sh
@@ -134,6 +134,9 @@ fi
 ESP_DISK="/dev/$ESP_PARENT"
 if [ ! -b "$ESP_DISK" ] || [ -z "$ESP_PARTNUM" ]; then
 	echo "ERROR: could not safely resolve the ESP's disk and partition from /esp; refusing to modify NVRAM." >&2
+	# Read-only mode was disabled at the top of this script; don't leave the
+	# system writable on the failure path.
+	sudo steamos-readonly enable
 	exit 1
 fi
 

--- a/SteamDeck_rEFInd_install.sh
+++ b/SteamDeck_rEFInd_install.sh
@@ -2,7 +2,9 @@
 # A simple Steam Deck rEFInd automated install script
 
 READONLY_DISABLED=0
+# Bazzite and ChimeraOS have no steamos-readonly; both helpers are no-ops there.
 disable_readonly() {
+	command -v steamos-readonly >/dev/null 2>&1 || return 0
 	if [ "$READONLY_DISABLED" -eq 1 ]; then
 		return 0
 	fi
@@ -13,6 +15,7 @@ disable_readonly() {
 	READONLY_DISABLED=1
 }
 enable_readonly() {
+	command -v steamos-readonly >/dev/null 2>&1 || return 0
 	if [ "$READONLY_DISABLED" -eq 0 ]; then
 		return 0
 	fi

--- a/SteamDeck_rEFInd_install.sh
+++ b/SteamDeck_rEFInd_install.sh
@@ -1,6 +1,38 @@
 #!/bin/bash
 # A simple Steam Deck rEFInd automated install script
 
+READONLY_DISABLED=0
+disable_readonly() {
+	if [ "$READONLY_DISABLED" -eq 1 ]; then
+		return 0
+	fi
+	if ! sudo steamos-readonly disable; then
+		echo "Error: could not disable SteamOS read-only mode." >&2
+		return 1
+	fi
+	READONLY_DISABLED=1
+}
+enable_readonly() {
+	if [ "$READONLY_DISABLED" -eq 0 ]; then
+		return 0
+	fi
+	if ! sudo steamos-readonly enable; then
+		echo "CRITICAL: SteamOS read-only mode could not be restored. Run 'sudo steamos-readonly enable' before rebooting." >&2
+		return 1
+	fi
+	READONLY_DISABLED=0
+}
+restore_readonly_on_exit() {
+	status=$?
+	trap - EXIT
+	if [ "$READONLY_DISABLED" -eq 1 ] && ! enable_readonly; then
+		status=70
+	fi
+	exit "$status"
+}
+trap restore_readonly_on_exit EXIT
+set -e
+
 # The invoking user, not a hardcoded "deck": this also runs on Bazzite,
 # ChimeraOS, and Decks whose user was renamed, where `passwd --status deck`
 # fails and every sudo call below would then fail too.
@@ -18,7 +50,7 @@ awk -v user="$INSTALL_USER" '{
 	}
 }' ~/deck_passwd_status.txt
 
-sudo steamos-readonly disable
+disable_readonly
 sudo pacman-key --init
 sudo pacman-key --populate archlinux
 sudo pacman -Sy --noconfirm --needed refind
@@ -61,7 +93,7 @@ rm -f "$XBOX360_DRV_TMP"
 # this driver produces AbsolutePointer so the rEFInd menu is touch-usable,
 # including rotating the portrait touch matrix onto rEFInd's landscape mode.
 # Like the controller driver, download failure is non-fatal.
-DECK_PRODUCT="$(cat /sys/class/dmi/id/product_name 2>/dev/null)"
+DECK_PRODUCT="$(cat /sys/class/dmi/id/product_name 2>/dev/null)" || true
 if [ "$DECK_PRODUCT" = "Galileo" ] || [ "$DECK_PRODUCT" = "Jupiter" ]; then
 	TOUCH_DRV_URL="https://github.com/jlobue10/TouchI2cDxe/releases/latest/download/TouchI2cDxe.efi"
 	TOUCH_DRV_TMP="$(mktemp)"
@@ -83,7 +115,7 @@ echo "Updating EFI boot entries..."
 # disk makes manual recovery trivial if anything goes sideways.
 NVRAM_BK_DIR="$HOME/.local/SteamDeck_rEFInd/nvram-backups"
 if mkdir -p "$NVRAM_BK_DIR" 2>/dev/null; then
-	efibootmgr -v > "$NVRAM_BK_DIR/efibootmgr-$(date +%Y%m%d-%H%M%S).txt" 2>/dev/null
+	efibootmgr -v > "$NVRAM_BK_DIR/efibootmgr-$(date +%Y%m%d-%H%M%S).txt" 2>/dev/null || true
 	# Keep the ten most recent snapshots.
 	ls -1t "$NVRAM_BK_DIR"/efibootmgr-*.txt 2>/dev/null | tail -n +11 | xargs -r rm -f
 fi
@@ -102,9 +134,6 @@ fi
 ESP_DISK="/dev/$ESP_PARENT"
 if [ ! -b "$ESP_DISK" ] || [ -z "$ESP_PARTNUM" ]; then
 	echo "ERROR: could not safely resolve the ESP's disk and partition from /esp; refusing to modify NVRAM." >&2
-	# Read-only mode was disabled at the top of this script; don't leave the
-	# system writable on the failure path.
-	sudo steamos-readonly enable
 	exit 1
 fi
 
@@ -177,9 +206,9 @@ if [ -n "$NEW_BOOTNUM" ]; then
 fi
 
 # Clean up temporary files, created for code clarity
-yes | rm $HOME/deck_passwd_status.txt
+rm -f "$HOME/deck_passwd_status.txt"
 
-sudo steamos-readonly enable
+enable_readonly || exit 70
 
 # Verify the result from live NVRAM rather than trusting the steps above.
 echo

--- a/install-GUI.sh
+++ b/install-GUI.sh
@@ -4,6 +4,38 @@
 # Designed to be piped from curl:
 #   curl -L https://github.com/jlobue10/SteamDeck_rEFInd/raw/main/install-GUI.sh | sh
 echo -e "Installing SteamDeck rEFInd...\n"
+
+READONLY_DISABLED=0
+disable_readonly() {
+    if [ "$READONLY_DISABLED" -eq 1 ]; then
+        return 0
+    fi
+    if ! sudo steamos-readonly disable; then
+        echo "Error: could not disable SteamOS read-only mode." >&2
+        return 1
+    fi
+    READONLY_DISABLED=1
+}
+enable_readonly() {
+    if [ "$READONLY_DISABLED" -eq 0 ]; then
+        return 0
+    fi
+    if ! sudo steamos-readonly enable; then
+        echo "CRITICAL: SteamOS read-only mode could not be restored. Run 'sudo steamos-readonly enable' before rebooting." >&2
+        return 1
+    fi
+    READONLY_DISABLED=0
+}
+restore_readonly_on_exit() {
+    status=$?
+    trap - EXIT
+    if [ "$READONLY_DISABLED" -eq 1 ] && ! enable_readonly; then
+        status=70
+    fi
+    exit "$status"
+}
+trap restore_readonly_on_exit EXIT
+
 cd "$HOME" || exit 1
 rm -rf "$HOME/SteamDeck_rEFInd"
 if ! git clone --depth 1 https://github.com/jlobue10/SteamDeck_rEFInd; then
@@ -40,9 +72,7 @@ if [ -n "$VERSION" ] && [ "$VERSION" != "null" ]; then
     fi
 fi
 
-sudo steamos-readonly disable
-# Make sure readonly gets re-enabled even if the script aborts partway through
-trap 'sudo steamos-readonly enable' EXIT
+disable_readonly || exit 1
 mkdir -p "$HOME/.local/SteamDeck_rEFInd/GUI"
 # Stage GUI/ file by file rather than with a blanket cp -rf: rEFInd_GUI.ini holds
 # every saved setting, and refind.conf / background.png / os_icon*.png are what
@@ -156,7 +186,7 @@ else
 fi
 rm -f "$CURRENT_WD/sudoers_rule.tmp"
 
-sudo steamos-readonly enable
+enable_readonly || exit 70
 
 # /usr is the immutable A/B rootfs: a SteamOS update replaces it wholesale and
 # takes the pacman-installed binary with it. The copy under $HOME/.local is on

--- a/install-GUI.sh
+++ b/install-GUI.sh
@@ -6,7 +6,9 @@
 echo -e "Installing SteamDeck rEFInd...\n"
 
 READONLY_DISABLED=0
+# Bazzite and ChimeraOS have no steamos-readonly; both helpers are no-ops there.
 disable_readonly() {
+    command -v steamos-readonly >/dev/null 2>&1 || return 0
     if [ "$READONLY_DISABLED" -eq 1 ]; then
         return 0
     fi
@@ -17,6 +19,7 @@ disable_readonly() {
     READONLY_DISABLED=1
 }
 enable_readonly() {
+    command -v steamos-readonly >/dev/null 2>&1 || return 0
     if [ "$READONLY_DISABLED" -eq 0 ]; then
         return 0
     fi

--- a/refind_install_no_pacman.sh
+++ b/refind_install_no_pacman.sh
@@ -127,6 +127,9 @@ fi
 ESP_DISK="/dev/$ESP_PARENT"
 if [ ! -b "$ESP_DISK" ] || [ -z "$ESP_PARTNUM" ]; then
 	echo "ERROR: could not safely resolve the ESP's disk and partition from /esp; refusing to modify NVRAM." >&2
+	# Read-only mode was disabled at the top of this script; don't leave the
+	# system writable on the failure path.
+	sudo steamos-readonly enable
 	exit 1
 fi
 

--- a/refind_install_no_pacman.sh
+++ b/refind_install_no_pacman.sh
@@ -3,7 +3,9 @@
 # Please make sure that a password exists for the deck user before running
 
 READONLY_DISABLED=0
+# Bazzite and ChimeraOS have no steamos-readonly; both helpers are no-ops there.
 disable_readonly() {
+	command -v steamos-readonly >/dev/null 2>&1 || return 0
 	if [ "$READONLY_DISABLED" -eq 1 ]; then
 		return 0
 	fi
@@ -14,6 +16,7 @@ disable_readonly() {
 	READONLY_DISABLED=1
 }
 enable_readonly() {
+	command -v steamos-readonly >/dev/null 2>&1 || return 0
 	if [ "$READONLY_DISABLED" -eq 0 ]; then
 		return 0
 	fi
@@ -49,7 +52,11 @@ sudo mkdir -p /esp/efi/refind
 yes | sudo cp ~/Downloads/refind-bin-0.14.2/refind/refind_x64.efi /esp/efi/refind/
 yes | sudo cp -rf ~/Downloads/refind-bin-0.14.2/refind/drivers_x64/ /esp/efi/refind
 yes | sudo cp -rf ~/Downloads/refind-bin-0.14.2/refind/tools_x64/ /esp/efi/refind
-yes | sudo ./refind-bin-0.14.2/refind-install
+# This script stages the rEFInd files and creates the NVRAM entry itself, so a
+# refind-install failure must not abort the install under set -e.
+if ! yes | sudo ./refind-bin-0.14.2/refind-install; then
+	echo "Warning: refind-install reported an error; continuing with manual file installation." >&2
+fi
 yes | sudo cp -rf ~/Downloads/refind-bin-0.14.2/refind/icons/ /esp/efi/refind
 yes | sudo cp -rf ~/Downloads/refind-bin-0.14.2/fonts/ /esp/efi/refind
 yes | sudo cp "$CURRENT_WD/refind.conf" /esp/efi/refind/refind.conf

--- a/refind_install_no_pacman.sh
+++ b/refind_install_no_pacman.sh
@@ -2,17 +2,49 @@
 # An alternate,  without pacman, rEFInd installation
 # Please make sure that a password exists for the deck user before running
 
+READONLY_DISABLED=0
+disable_readonly() {
+	if [ "$READONLY_DISABLED" -eq 1 ]; then
+		return 0
+	fi
+	if ! sudo steamos-readonly disable; then
+		echo "Error: could not disable SteamOS read-only mode." >&2
+		return 1
+	fi
+	READONLY_DISABLED=1
+}
+enable_readonly() {
+	if [ "$READONLY_DISABLED" -eq 0 ]; then
+		return 0
+	fi
+	if ! sudo steamos-readonly enable; then
+		echo "CRITICAL: SteamOS read-only mode could not be restored. Run 'sudo steamos-readonly enable' before rebooting." >&2
+		return 1
+	fi
+	READONLY_DISABLED=0
+}
+restore_readonly_on_exit() {
+	status=$?
+	trap - EXIT
+	if [ "$READONLY_DISABLED" -eq 1 ] && ! enable_readonly; then
+		status=70
+	fi
+	exit "$status"
+}
+trap restore_readonly_on_exit EXIT
+set -e
+
 CURRENT_WD=$(pwd)
 cd ~/Downloads || exit 1
-wget -O refind-bin-gnuefi-0.14.2.zip https://sourceforge.net/projects/refind/files/0.14.2/refind-bin-gnuefi-0.14.2.zip
-if [ $? -ne 0 ] || [ ! -s refind-bin-gnuefi-0.14.2.zip ]; then
+if ! wget -O refind-bin-gnuefi-0.14.2.zip https://sourceforge.net/projects/refind/files/0.14.2/refind-bin-gnuefi-0.14.2.zip ||
+	[ ! -s refind-bin-gnuefi-0.14.2.zip ]; then
     echo "Error: failed to download rEFInd from Sourceforge. Aborting." >&2
     exit 1
 fi
 unzip -t refind-bin-gnuefi-0.14.2.zip >/dev/null || { echo "Error: downloaded zip is corrupt. Aborting." >&2; exit 1; }
 unzip -a -o refind-bin-gnuefi-0.14.2.zip
 
-sudo steamos-readonly disable
+disable_readonly
 sudo mkdir -p /esp/efi/refind
 yes | sudo cp ~/Downloads/refind-bin-0.14.2/refind/refind_x64.efi /esp/efi/refind/
 yes | sudo cp -rf ~/Downloads/refind-bin-0.14.2/refind/drivers_x64/ /esp/efi/refind
@@ -54,7 +86,7 @@ rm -f "$XBOX360_DRV_TMP"
 # this driver produces AbsolutePointer so the rEFInd menu is touch-usable,
 # including rotating the portrait touch matrix onto rEFInd's landscape mode.
 # Like the controller driver, download failure is non-fatal.
-DECK_PRODUCT="$(cat /sys/class/dmi/id/product_name 2>/dev/null)"
+DECK_PRODUCT="$(cat /sys/class/dmi/id/product_name 2>/dev/null)" || true
 if [ "$DECK_PRODUCT" = "Galileo" ] || [ "$DECK_PRODUCT" = "Jupiter" ]; then
 	TOUCH_DRV_URL="https://github.com/jlobue10/TouchI2cDxe/releases/latest/download/TouchI2cDxe.efi"
 	TOUCH_DRV_TMP="$(mktemp)"
@@ -76,7 +108,7 @@ echo "Updating EFI boot entries..."
 # disk makes manual recovery trivial if anything goes sideways.
 NVRAM_BK_DIR="$HOME/.local/SteamDeck_rEFInd/nvram-backups"
 if mkdir -p "$NVRAM_BK_DIR" 2>/dev/null; then
-	efibootmgr -v > "$NVRAM_BK_DIR/efibootmgr-$(date +%Y%m%d-%H%M%S).txt" 2>/dev/null
+	efibootmgr -v > "$NVRAM_BK_DIR/efibootmgr-$(date +%Y%m%d-%H%M%S).txt" 2>/dev/null || true
 	# Keep the ten most recent snapshots.
 	ls -1t "$NVRAM_BK_DIR"/efibootmgr-*.txt 2>/dev/null | tail -n +11 | xargs -r rm -f
 fi
@@ -95,9 +127,6 @@ fi
 ESP_DISK="/dev/$ESP_PARENT"
 if [ ! -b "$ESP_DISK" ] || [ -z "$ESP_PARTNUM" ]; then
 	echo "ERROR: could not safely resolve the ESP's disk and partition from /esp; refusing to modify NVRAM." >&2
-	# Read-only mode was disabled at the top of this script; don't leave the
-	# system writable on the failure path.
-	sudo steamos-readonly enable
 	exit 1
 fi
 
@@ -169,7 +198,7 @@ if [ -n "$NEW_BOOTNUM" ]; then
 		|| echo "Warning: could not set rEFInd as the next boot." >&2
 fi
 
-sudo steamos-readonly enable
+enable_readonly || exit 70
 
 # Verify the result from live NVRAM rather than trusting the steps above.
 echo

--- a/scripts/uninstall_rEFInd.sh
+++ b/scripts/uninstall_rEFInd.sh
@@ -37,7 +37,9 @@ for arg in "$@"; do
 done
 
 READONLY_DISABLED=0
+# Bazzite and ChimeraOS have no steamos-readonly; both helpers are no-ops there.
 disable_readonly() {
+	command -v steamos-readonly >/dev/null 2>&1 || return 0
 	if [ "$READONLY_DISABLED" -eq 1 ]; then
 		return 0
 	fi
@@ -48,6 +50,7 @@ disable_readonly() {
 	READONLY_DISABLED=1
 }
 enable_readonly() {
+	command -v steamos-readonly >/dev/null 2>&1 || return 0
 	if [ "$READONLY_DISABLED" -eq 0 ]; then
 		return 0
 	fi
@@ -178,8 +181,11 @@ fi
 # 6. Remove the pacman-installed refind package (the Sourceforge install path
 # leaves no package; its rootfs files are covered by the ESP cleanup above).
 if pacman -Qq refind >/dev/null 2>&1; then
-	run_with_writable_root sudo pacman -R --noconfirm refind || exit $?
-	echo "Removed the refind pacman package."
+	if run_with_writable_root sudo pacman -R --noconfirm refind; then
+		echo "Removed the refind pacman package."
+	else
+		echo "Warning: could not remove the refind pacman package; continuing." >&2
+	fi
 fi
 
 # 7. Optionally remove the GUI app itself.

--- a/scripts/uninstall_rEFInd.sh
+++ b/scripts/uninstall_rEFInd.sh
@@ -36,6 +36,46 @@ for arg in "$@"; do
 	esac
 done
 
+READONLY_DISABLED=0
+disable_readonly() {
+	if [ "$READONLY_DISABLED" -eq 1 ]; then
+		return 0
+	fi
+	if ! sudo steamos-readonly disable; then
+		echo "Error: could not disable SteamOS read-only mode." >&2
+		return 1
+	fi
+	READONLY_DISABLED=1
+}
+enable_readonly() {
+	if [ "$READONLY_DISABLED" -eq 0 ]; then
+		return 0
+	fi
+	if ! sudo steamos-readonly enable; then
+		echo "CRITICAL: SteamOS read-only mode could not be restored. Run 'sudo steamos-readonly enable' before rebooting." >&2
+		return 1
+	fi
+	READONLY_DISABLED=0
+}
+restore_readonly_on_exit() {
+	status=$?
+	trap - EXIT
+	if [ "$READONLY_DISABLED" -eq 1 ] && ! enable_readonly; then
+		status=70
+	fi
+	exit "$status"
+}
+run_with_writable_root() {
+	disable_readonly || return 1
+	"$@"
+	command_status=$?
+	if ! enable_readonly; then
+		return 70
+	fi
+	return "$command_status"
+}
+trap restore_readonly_on_exit EXIT
+
 RefindLoaderRegex='\\refind\\refind[^\\]*\.efi'
 
 echo "Removing the Deck-side rEFInd install..."
@@ -130,9 +170,7 @@ if [ "$KEEP_ESP_FILES" -eq 0 ] && [ -n "$ESP_MP" ]; then
 		fi
 	done
 	if sudo test -f /boot/refind_linux.conf; then
-		sudo steamos-readonly disable
-		sudo rm -f /boot/refind_linux.conf
-		sudo steamos-readonly enable
+		run_with_writable_root sudo rm -f /boot/refind_linux.conf || exit $?
 		echo "Removed /boot/refind_linux.conf."
 	fi
 fi
@@ -140,9 +178,7 @@ fi
 # 6. Remove the pacman-installed refind package (the Sourceforge install path
 # leaves no package; its rootfs files are covered by the ESP cleanup above).
 if pacman -Qq refind >/dev/null 2>&1; then
-	sudo steamos-readonly disable
-	sudo pacman -R --noconfirm refind
-	sudo steamos-readonly enable
+	run_with_writable_root sudo pacman -R --noconfirm refind || exit $?
 	echo "Removed the refind pacman package."
 fi
 
@@ -150,9 +186,7 @@ fi
 if [ "$REMOVE_APP" -eq 1 ]; then
 	echo "Removing the SteamDeck_rEFInd app..."
 	if pacman -Qq SteamDeck_rEFInd >/dev/null 2>&1; then
-		sudo steamos-readonly disable
-		sudo pacman -R --noconfirm SteamDeck_rEFInd
-		sudo steamos-readonly enable
+		run_with_writable_root sudo pacman -R --noconfirm SteamDeck_rEFInd || exit $?
 	else
 		echo "No installed SteamDeck_rEFInd package found; removing files only."
 	fi


### PR DESCRIPTION
## Summary
- track whether each installer or uninstaller actually disabled SteamOS read-only mode
- restore immutability from an `EXIT` guard on failures and interruptions
- check normal restoration explicitly and stop with a critical recovery message/status when it fails
- make the two legacy installers fail fast while preserving intentional best-effort hardware-driver and NVRAM-backup behavior
- run each uninstall rootfs mutation through a checked writable-root wrapper

This preserves the existing SteamOS design: persistent service/configuration state remains under `/etc`, and the release workflow remains tag/manual only.

## Validation
- `bash -n install-GUI.sh SteamDeck_rEFInd_install.sh refind_install_no_pacman.sh scripts/uninstall_rEFInd.sh`
- `git diff --check`
- mocked lifecycle tests verified restoration after status 23, escalation to status 70 when restoration fails, and restoration after a failed uninstall mutation

Drafted as one focused fix from the security/bug audit.