### PR TITLE
Configure the randomizer for the installing user

### DIFF
--- a/install-GUI.sh
+++ b/install-GUI.sh
@@ -143,6 +143,33 @@ sudo install -o root -g root -m 0644 \
     "$CURRENT_WD/scripts/lib_esp_target.sh" \
     /etc/SteamDeck_rEFInd/lib_esp_target.sh
 
+# The randomizer runs as root under systemd, where $HOME is /root. Record the
+# actual desktop user's backgrounds directory as data in a root-owned file on
+# SteamOS's persistent /etc overlay. The service validates and reads this file;
+# it never sources it as shell code.
+case "$HOME" in
+    /*) ;;
+    *)
+        echo "Error: HOME is not an absolute path; refusing to configure the background randomizer." >&2
+        exit 1
+        ;;
+esac
+case "$HOME" in
+    *$'\n'*)
+        echo "Error: HOME contains a newline; refusing to create a malformed randomizer configuration." >&2
+        exit 1
+        ;;
+esac
+BG_DIR_CONFIG_TMP="$(mktemp)" || exit 1
+if ! printf '%s\n' "$HOME/.local/SteamDeck_rEFInd/backgrounds" > "$BG_DIR_CONFIG_TMP" ||
+    ! sudo install -o root -g root -m 0644 "$BG_DIR_CONFIG_TMP" \
+        /etc/SteamDeck_rEFInd/background-dir; then
+    rm -f "$BG_DIR_CONFIG_TMP"
+    echo "Error: could not install the background randomizer path configuration." >&2
+    exit 1
+fi
+rm -f "$BG_DIR_CONFIG_TMP"
+
 INSTALL_USER="$(id -un)"
 sed "s/^USER /$INSTALL_USER /" "$CURRENT_WD/scripts/zz_SteamDeck_rEFInd_install_config" \
     > "$CURRENT_WD/sudoers_rule.tmp"

--- a/scripts/rEFInd_bg_randomizer.sh
+++ b/scripts/rEFInd_bg_randomizer.sh
@@ -1,8 +1,46 @@
 #!/bin/bash
-# Invoked only by systemd/rEFInd_bg_randomizer.service as root, so $HOME is not
-# reliably the deck user's home here -- keep this path hardcoded to match the
-# service's own hardcoded assumption (see systemd/rEFInd_bg_randomizer.service).
+# Invoked by systemd as root, so $HOME cannot identify the desktop user. The
+# GUI installer records the invoking user's background directory as one plain
+# line in a root-owned file on SteamOS's persistent /etc overlay. Never source
+# this file: even if its ownership were accidentally weakened, its contents
+# must remain data rather than shell code.
+BG_DIR_CONFIG=/etc/SteamDeck_rEFInd/background-dir
 BG_DIR=/home/deck/.local/SteamDeck_rEFInd/backgrounds
+
+load_background_dir() {
+    local owner mode configured extra
+
+    [ -f "$BG_DIR_CONFIG" ] && [ ! -L "$BG_DIR_CONFIG" ] || return 1
+    owner="$(stat -c '%u:%g' -- "$BG_DIR_CONFIG" 2>/dev/null)" || return 1
+    mode="$(stat -c '%a' -- "$BG_DIR_CONFIG" 2>/dev/null)" || return 1
+    [ "$owner" = "0:0" ] || return 1
+    # Owner may write; group and other must not. Reject special mode bits too.
+    case "$mode" in
+        [0-7][0145][0145]) ;;
+        *) return 1 ;;
+    esac
+
+    exec 3< "$BG_DIR_CONFIG" || return 1
+    IFS= read -r configured <&3 || {
+        exec 3<&-
+        return 1
+    }
+    if IFS= read -r extra <&3; then
+        exec 3<&-
+        return 1
+    fi
+    exec 3<&-
+    case "$configured" in
+        /*) printf '%s\n' "$configured" ;;
+        *) return 1 ;;
+    esac
+}
+
+if CONFIGURED_BG_DIR="$(load_background_dir)"; then
+    BG_DIR="$CONFIGURED_BG_DIR"
+elif [ -e "$BG_DIR_CONFIG" ] || [ -L "$BG_DIR_CONFIG" ]; then
+    echo "rEFInd_bg_randomizer: ignoring unsafe or malformed $BG_DIR_CONFIG" >&2
+fi
 
 # The destination used to be hardcoded to /esp/efi/refind/, which silently wrote
 # to the wrong place whenever rEFInd lives on another ESP (a Windows-side or


### PR DESCRIPTION
## Summary
- record the actual installer user's backgrounds directory in `/etc/SteamDeck_rEFInd/background-dir`, which persists across SteamOS updates
- install that record root-owned and non-writable by group/other
- treat the record strictly as one line of data, never shell-source it
- validate ownership, mode, file type, shape, and absolute-path form before use
- retain `/home/deck` only as a compatibility fallback for installations predating the path record

The release workflow remains unchanged and still builds only on tags/manual dispatch.

## Validation
- `bash -n install-GUI.sh scripts/rEFInd_bg_randomizer.sh`
- `git diff --check`
- parser fixtures accepted an absolute path containing spaces and rejected writable, multiline, relative, and symlinked configurations

Drafted as one focused fix from the security/bug audit.