### PR TITLE
Harden root randomizer input handling

### DIFF
--- a/scripts/rEFInd_bg_randomizer.sh
+++ b/scripts/rEFInd_bg_randomizer.sh
@@ -10,15 +10,63 @@ BG_DIR=/home/deck/.local/SteamDeck_rEFInd/backgrounds
 # randomizer do. Already root here, so no password prompt is involved.
 # shellcheck source=/dev/null
 . "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/lib_esp_target.sh" || exit 1
-trap esp_cleanup EXIT
+CANDIDATE_FILE=""
+STAGED_BG=""
+TARGET_TMP=""
+randomizer_cleanup() {
+    [ -z "$TARGET_TMP" ] || rm -f -- "$TARGET_TMP"
+    [ -z "$STAGED_BG" ] || rm -f -- "$STAGED_BG"
+    [ -z "$CANDIDATE_FILE" ] || rm -f -- "$CANDIDATE_FILE"
+    esp_cleanup
+}
+trap randomizer_cleanup EXIT
 
-# -type f (not -L) and an anchored *.png glob on purpose: this runs as root at
-# every boot over a directory the desktop user owns, so following a symlink
-# named *.png would copy any root-readable file onto the ESP, and the old
-# `ls | grep .png` also matched unanchored ("notes-png.txt") and broke on
-# spaces in filenames.
-RAND_BG="$(find "$BG_DIR" -maxdepth 1 -type f -iname '*.png' 2>/dev/null | shuf -n1)"
-[ -n "$RAND_BG" ] || exit 0
+# This unit is root, but its input directory belongs to the desktop user. A
+# find(1) -type check followed by a root cp(1) is not sufficient: the selected
+# path can be swapped for a symlink between those operations. Select and open
+# the file under the directory owner's unprivileged account instead. The root
+# process receives bytes only, into a private temporary file with a size/time
+# bound, then validates the PNG signature before touching the ESP.
+BG_OWNER_UID="$(stat -Lc '%u' -- "$BG_DIR" 2>/dev/null)" || exit 0
+case "$BG_OWNER_UID" in
+    ''|*[!0-9]*|0)
+        echo "rEFInd_bg_randomizer: refusing a background directory without a non-root owner" >&2
+        exit 1
+        ;;
+esac
+BG_OWNER="$(getent passwd "$BG_OWNER_UID" | cut -d: -f1)"
+if [ -z "$BG_OWNER" ] || [ "$BG_OWNER" = root ] || ! command -v runuser >/dev/null 2>&1; then
+    echo "rEFInd_bg_randomizer: could not resolve a safe account for the background directory" >&2
+    exit 1
+fi
+
+CANDIDATE_FILE="$(mktemp)" || exit 1
+if ! (
+    set -o pipefail
+    timeout 10s runuser -u "$BG_OWNER" -- \
+        find "$BG_DIR" -maxdepth 1 -type f -readable -iname '*.png' -print0 2>/dev/null | \
+        shuf -z -n1
+) > "$CANDIDATE_FILE"; then
+    echo "rEFInd_bg_randomizer: could not enumerate background images safely" >&2
+    exit 1
+fi
+[ -s "$CANDIDATE_FILE" ] || exit 0
+
+STAGED_BG="$(mktemp)" || exit 1
+if ! (
+    # Bash expresses RLIMIT_FSIZE in KiB. This caps a malicious or accidental
+    # oversized input at 32 MiB before it can consume the root filesystem.
+    ulimit -f 32768 || exit 1
+    xargs -0 -r timeout 10s runuser -u "$BG_OWNER" -- cat -- < "$CANDIDATE_FILE"
+) > "$STAGED_BG"; then
+    echo "rEFInd_bg_randomizer: could not read the selected background safely" >&2
+    exit 1
+fi
+PNG_SIGNATURE="$(od -An -tx1 -N8 -- "$STAGED_BG" 2>/dev/null | tr -d '[:space:]')"
+if [ "$PNG_SIGNATURE" != 89504e470d0a1a0a ]; then
+    echo "rEFInd_bg_randomizer: selected background is not a valid PNG file" >&2
+    exit 1
+fi
 
 RESOLVED="$(resolve_refind_dir)" || {
     echo "rEFInd_bg_randomizer: no ESP with rEFInd on it; nothing to update" >&2
@@ -27,6 +75,9 @@ RESOLVED="$(resolve_refind_dir)" || {
 TARGET="${RESOLVED%%|*}"
 
 esp_make_writable "$TARGET"
-cp -f "$RAND_BG" "$TARGET/background.png" || exit 1
+TARGET_TMP="$(mktemp "$TARGET/.background.png.XXXXXX")" || exit 1
+cp -f -- "$STAGED_BG" "$TARGET_TMP" || exit 1
+mv -f -- "$TARGET_TMP" "$TARGET/background.png" || exit 1
+TARGET_TMP=""
 # Flush before a temporary mount (if one was made) is torn down by the trap.
 sync

--- a/scripts/rEFInd_bg_randomizer.sh
+++ b/scripts/rEFInd_bg_randomizer.sh
@@ -27,17 +27,22 @@ trap randomizer_cleanup EXIT
 # the file under the directory owner's unprivileged account instead. The root
 # process receives bytes only, into a private temporary file with a size/time
 # bound, then validates the PNG signature before touching the ESP.
+#
+# This is a cosmetic boot-time unit, so a problem with the user's content or
+# the environment warns and exits 0 rather than leaving a failed unit behind
+# on the ~1/N boots that a bad file happens to be drawn. Nonzero exits are
+# reserved for internal errors (mktemp and friends).
 BG_OWNER_UID="$(stat -Lc '%u' -- "$BG_DIR" 2>/dev/null)" || exit 0
 case "$BG_OWNER_UID" in
     ''|*[!0-9]*|0)
         echo "rEFInd_bg_randomizer: refusing a background directory without a non-root owner" >&2
-        exit 1
+        exit 0
         ;;
 esac
 BG_OWNER="$(getent passwd "$BG_OWNER_UID" | cut -d: -f1)"
 if [ -z "$BG_OWNER" ] || [ "$BG_OWNER" = root ] || ! command -v runuser >/dev/null 2>&1; then
     echo "rEFInd_bg_randomizer: could not resolve a safe account for the background directory" >&2
-    exit 1
+    exit 0
 fi
 
 CANDIDATE_FILE="$(mktemp)" || exit 1
@@ -45,32 +50,57 @@ if ! (
     set -o pipefail
     timeout 10s runuser -u "$BG_OWNER" -- \
         find "$BG_DIR" -maxdepth 1 -type f -readable -iname '*.png' -print0 2>/dev/null | \
-        shuf -z -n1
+        shuf -z
 ) > "$CANDIDATE_FILE"; then
-    echo "rEFInd_bg_randomizer: could not enumerate background images safely" >&2
-    exit 1
+    echo "rEFInd_bg_randomizer: could not enumerate background images safely; keeping the current background" >&2
+    exit 0
 fi
 [ -s "$CANDIDATE_FILE" ] || exit 0
 
+# A single bad file (renamed JPEG, oversized, unreadable) should not spoil the
+# boot: walk the shuffled candidates and take the first one that validates,
+# bounded so a directory full of junk still finishes quickly.
+MAX_BG_BYTES=33554432
+MAX_ATTEMPTS=3
 STAGED_BG="$(mktemp)" || exit 1
-if ! (
-    # Bash expresses RLIMIT_FSIZE in KiB. This caps a malicious or accidental
-    # oversized input at 32 MiB before it can consume the root filesystem.
-    ulimit -f 32768 || exit 1
-    xargs -0 -r timeout 10s runuser -u "$BG_OWNER" -- cat -- < "$CANDIDATE_FILE"
-) > "$STAGED_BG"; then
-    echo "rEFInd_bg_randomizer: could not read the selected background safely" >&2
-    exit 1
-fi
-PNG_SIGNATURE="$(od -An -tx1 -N8 -- "$STAGED_BG" 2>/dev/null | tr -d '[:space:]')"
-if [ "$PNG_SIGNATURE" != 89504e470d0a1a0a ]; then
-    echo "rEFInd_bg_randomizer: selected background is not a valid PNG file" >&2
-    exit 1
+STAGED_OK=""
+ATTEMPTS=0
+while IFS= read -r -d '' CANDIDATE; do
+    [ "$ATTEMPTS" -lt "$MAX_ATTEMPTS" ] || break
+    ATTEMPTS=$((ATTEMPTS + 1))
+    # head(1) enforces the 32 MiB cap in the pipe itself: an RLIMIT_FSIZE
+    # ulimit would have to survive runuser's PAM stack, where pam_limits can
+    # silently replace it from limits.conf.
+    if ! (
+        set -o pipefail
+        timeout 10s runuser -u "$BG_OWNER" -- cat -- "$CANDIDATE" | \
+            head -c "$MAX_BG_BYTES"
+    ) > "$STAGED_BG"; then
+        echo "rEFInd_bg_randomizer: could not read '$CANDIDATE' safely; trying another" >&2
+        continue
+    fi
+    # Exactly at the cap means head(1) may have truncated a larger file.
+    STAGED_SIZE="$(stat -c '%s' -- "$STAGED_BG" 2>/dev/null)" || continue
+    if [ "$STAGED_SIZE" -ge "$MAX_BG_BYTES" ]; then
+        echo "rEFInd_bg_randomizer: '$CANDIDATE' exceeds ${MAX_BG_BYTES} bytes; trying another" >&2
+        continue
+    fi
+    PNG_SIGNATURE="$(od -An -tx1 -N8 -- "$STAGED_BG" 2>/dev/null | tr -d '[:space:]')"
+    if [ "$PNG_SIGNATURE" != 89504e470d0a1a0a ]; then
+        echo "rEFInd_bg_randomizer: '$CANDIDATE' is not a valid PNG file; trying another" >&2
+        continue
+    fi
+    STAGED_OK=1
+    break
+done < "$CANDIDATE_FILE"
+if [ -z "$STAGED_OK" ]; then
+    echo "rEFInd_bg_randomizer: no usable background image found; keeping the current background" >&2
+    exit 0
 fi
 
 RESOLVED="$(resolve_refind_dir)" || {
     echo "rEFInd_bg_randomizer: no ESP with rEFInd on it; nothing to update" >&2
-    exit 1
+    exit 0
 }
 TARGET="${RESOLVED%%|*}"
 


### PR DESCRIPTION
## Summary
- close the symlink-swap/TOCTOU gap between checking a user-owned background and reopening it as root
- enumerate and open candidates through `runuser` as the non-root directory owner
- use NUL-delimited paths so unusual filenames cannot alter argument boundaries
- bound reads to 10 seconds and 32 MiB, then require the PNG signature
- stage root-owned bytes and atomically rename the completed image onto the ESP
- clean temporary files before ESP unmount cleanup

The release workflow remains unchanged and still builds only on tags/manual dispatch.

## Validation
- `bash -n scripts/rEFInd_bg_randomizer.sh`
- `git diff --check`
- end-to-end transformed-script fixture accepted a valid PNG with a newline in its filename, published the expected signature atomically, and left no target temp files
- invalid-PNG fixture exited nonzero and published nothing

The container blocks real setuid transitions, so the test harness bypassed `runuser`; production code applies `runuser` to both `find` and `cat` and refuses UID 0.

Drafted as a separate security fix discovered during the audit.

## Review fixes

- **Failure-mode semantics**: content problems (JPEG renamed `.png`, oversized file) and environment problems (root-owned background dir, unresolvable owner, no ESP with rEFInd) now warn to stderr and exit 0 instead of leaving a nondeterministically failed unit on the boots that file is drawn. Nonzero exits remain only for internal errors (`mktemp` failure).
- **Retry**: candidates are enumerated shuffled and up to 3 are tried, so a single junk file no longer skips the boot's background update.
- **PAM-proof size cap**: `ulimit -f` replaced with `head -c 33554432` in the read pipeline (RLIMIT_FSIZE can be silently overridden by pam_limits under `runuser`); a staged file at exactly the cap is treated as truncated and rejected.

Re-validated with the fixture harness: valid PNG published; renamed JPEG, oversized file, all-junk dir, and empty dir all warn (or stay silent) and exit 0 with nothing published; mixed dir publishes the valid PNG on every run. `git merge-tree` confirms this branch still merges cleanly with #211.
