### PR TITLE
Theme-aware boot screen preview

### DIFF
--- a/GUI/src/SteamDeck_rEFInd_ar.ts
+++ b/GUI/src/SteamDeck_rEFInd_ar.ts
@@ -120,7 +120,7 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="468"/>
-        <location filename="mainwindow.cpp" line="1590"/>
+        <location filename="mainwindow.cpp" line="1613"/>
         <source>Open Folder</source>
         <translation>فتح المجلد</translation>
     </message>
@@ -280,9 +280,9 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="965"/>
-        <location filename="mainwindow.cpp" line="1545"/>
-        <location filename="mainwindow.cpp" line="1560"/>
-        <location filename="mainwindow.cpp" line="1565"/>
+        <location filename="mainwindow.cpp" line="1568"/>
+        <location filename="mainwindow.cpp" line="1583"/>
+        <location filename="mainwindow.cpp" line="1588"/>
         <source>Install Themes</source>
         <translation>تثبيت السمات</translation>
     </message>
@@ -325,10 +325,10 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="1080"/>
-        <location filename="mainwindow.cpp" line="1086"/>
-        <location filename="mainwindow.cpp" line="1104"/>
-        <location filename="mainwindow.cpp" line="1110"/>
-        <location filename="mainwindow.cpp" line="1115"/>
+        <location filename="mainwindow.cpp" line="1109"/>
+        <location filename="mainwindow.cpp" line="1127"/>
+        <location filename="mainwindow.cpp" line="1133"/>
+        <location filename="mainwindow.cpp" line="1138"/>
         <source>Install Config</source>
         <translation>تثبيت الإعدادات</translation>
     </message>
@@ -491,7 +491,7 @@
         <translation>تعذّرت كتابة %1 كاملًا — قد يكون القرص ممتلئًا. لم يتم تحديث الإعدادات.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1087"/>
+        <location filename="mainwindow.cpp" line="1110"/>
         <source>The config-install script was NOT run:
 
 %1
@@ -508,18 +508,18 @@ Reinstall the GUI to restore the original script, then try again.</source>
 أعد تثبيت الواجهة لاستعادة السكربت الأصلي ثم حاول مجددًا.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1105"/>
-        <location filename="mainwindow.cpp" line="1117"/>
+        <location filename="mainwindow.cpp" line="1128"/>
+        <location filename="mainwindow.cpp" line="1140"/>
         <source>Installing the config failed (code %1).</source>
         <translation>فشل تثبيت الإعدادات (الرمز %1).</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1112"/>
+        <location filename="mainwindow.cpp" line="1135"/>
         <source>The config was installed successfully.</source>
         <translation>تم تثبيت الإعدادات بنجاح.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1113"/>
+        <location filename="mainwindow.cpp" line="1136"/>
         <source>The config was installed successfully.
 
 %1</source>
@@ -528,7 +528,7 @@ Reinstall the GUI to restore the original script, then try again.</source>
 %1</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1118"/>
+        <location filename="mainwindow.cpp" line="1141"/>
         <source>Installing the config failed (code %1).
 
 %2</source>
@@ -537,28 +537,28 @@ Reinstall the GUI to restore the original script, then try again.</source>
 %2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1138"/>
-        <location filename="mainwindow.cpp" line="1148"/>
-        <location filename="mainwindow.cpp" line="1155"/>
+        <location filename="mainwindow.cpp" line="1161"/>
+        <location filename="mainwindow.cpp" line="1171"/>
+        <location filename="mainwindow.cpp" line="1178"/>
         <source>Copy PNG</source>
         <translation>نسخ PNG</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="935"/>
         <location filename="mainwindow.cpp" line="944"/>
-        <location filename="mainwindow.cpp" line="1139"/>
-        <location filename="mainwindow.cpp" line="1149"/>
-        <location filename="mainwindow.cpp" line="1156"/>
+        <location filename="mainwindow.cpp" line="1162"/>
+        <location filename="mainwindow.cpp" line="1172"/>
+        <location filename="mainwindow.cpp" line="1179"/>
         <source>Could not copy %1 to %2</source>
         <translation>تعذّر نسخ %1 إلى %2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1181"/>
+        <location filename="mainwindow.cpp" line="1204"/>
         <source>Invalid PNG</source>
         <translation>ملف PNG غير صالح</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1182"/>
+        <location filename="mainwindow.cpp" line="1205"/>
         <source>%1 is not a valid PNG file.
 
 Backgrounds and OS icons must be real PNG images (not just files with a .png extension).</source>
@@ -567,58 +567,58 @@ Backgrounds and OS icons must be real PNG images (not just files with a .png ext
 يجب أن تكون الخلفيات وأيقونات الأنظمة صور PNG حقيقية (وليست مجرد ملفات بامتداد ‎.png).</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1445"/>
+        <location filename="mainwindow.cpp" line="1468"/>
         <source>Check For Update</source>
         <translation>التحقق من التحديثات</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1448"/>
+        <location filename="mainwindow.cpp" line="1471"/>
         <source>&lt;p align=&apos;center&apos;&gt;&lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd&apos;&gt;rEFInd Customization GUI v%1&lt;/a&gt;&lt;br&gt;&lt;br&gt;Original GUI Creator: &lt;a href=&apos;https://github.com/jlobue10&apos;&gt;jlobue10&lt;/a&gt;&lt;br&gt;&lt;br&gt;Special Thanks to Deck Wizard for testing and QA&lt;br&gt;&lt;br&gt;&lt;a href=&apos;https://www.youtube.com/watch?v=yBHzVSDVEqw&apos;&gt;Deck Wizard Dual Boot Tutorial&lt;/a&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;&lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd&apos;&gt;rEFInd Customization GUI v%1&lt;/a&gt;&lt;br&gt;&lt;br&gt;مطوّر الواجهة الأصلي: &lt;a href=&apos;https://github.com/jlobue10&apos;&gt;jlobue10&lt;/a&gt;&lt;br&gt;&lt;br&gt;شكر خاص لـ Deck Wizard على الاختبار وضمان الجودة&lt;br&gt;&lt;br&gt;&lt;a href=&apos;https://www.youtube.com/watch?v=yBHzVSDVEqw&apos;&gt;شرح الإقلاع المزدوج من Deck Wizard&lt;/a&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1497"/>
+        <location filename="mainwindow.cpp" line="1520"/>
         <source>&lt;p align=&apos;center&apos;&gt;Update check failed. Please check your internet connection and try again.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;فشل التحقق من التحديثات. يُرجى التحقق من اتصالك بالإنترنت والمحاولة مجددًا.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1500"/>
+        <location filename="mainwindow.cpp" line="1523"/>
         <source>&lt;p align=&apos;center&apos;&gt;An update is available &lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd/releases&apos;&gt;here&lt;/a&gt;&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;يتوفر تحديث &lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd/releases&apos;&gt;هنا&lt;/a&gt;&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1504"/>
+        <location filename="mainwindow.cpp" line="1527"/>
         <source>&lt;p align=&apos;center&apos;&gt;No update found. You are using the latest version.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;لا توجد تحديثات. أنت تستخدم أحدث إصدار.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1514"/>
-        <location filename="mainwindow.cpp" line="1521"/>
+        <location filename="mainwindow.cpp" line="1537"/>
+        <location filename="mainwindow.cpp" line="1544"/>
         <source>systemd service</source>
         <translation>خدمة systemd</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1515"/>
-        <location filename="mainwindow.cpp" line="1522"/>
+        <location filename="mainwindow.cpp" line="1538"/>
+        <location filename="mainwindow.cpp" line="1545"/>
         <source>Failed to launch the service toggle.</source>
         <translation>تعذّر تشغيل تبديل الخدمة.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1528"/>
-        <location filename="mainwindow.cpp" line="1535"/>
+        <location filename="mainwindow.cpp" line="1551"/>
+        <location filename="mainwindow.cpp" line="1558"/>
         <source>Background Randomizer</source>
         <translation>الخلفية العشوائية</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1529"/>
-        <location filename="mainwindow.cpp" line="1536"/>
-        <location filename="mainwindow.cpp" line="1577"/>
-        <location filename="mainwindow.cpp" line="1584"/>
+        <location filename="mainwindow.cpp" line="1552"/>
+        <location filename="mainwindow.cpp" line="1559"/>
+        <location filename="mainwindow.cpp" line="1600"/>
+        <location filename="mainwindow.cpp" line="1607"/>
         <source>Failed to launch the randomizer setup.</source>
         <translation>تعذّر تشغيل إعداد الخلفية العشوائية.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1546"/>
+        <location filename="mainwindow.cpp" line="1569"/>
         <source>The themes-install script was NOT run:
 
 %1
@@ -635,12 +635,12 @@ Reinstall the GUI (on SteamOS, re-run install-GUI.sh) to install or restore it, 
 أعد تثبيت الواجهة (على SteamOS، أعد تشغيل install-GUI.sh) لتثبيته أو استعادته ثم حاول مجددًا.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1562"/>
+        <location filename="mainwindow.cpp" line="1585"/>
         <source>The themes were installed successfully.</source>
         <translation>تم تثبيت السمات بنجاح.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1563"/>
+        <location filename="mainwindow.cpp" line="1586"/>
         <source>The themes were installed successfully.
 
 %1</source>
@@ -649,12 +649,12 @@ Reinstall the GUI (on SteamOS, re-run install-GUI.sh) to install or restore it, 
 %1</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1567"/>
+        <location filename="mainwindow.cpp" line="1590"/>
         <source>Installing the themes failed (code %1).</source>
         <translation>فشل تثبيت السمات (الرمز %1).</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1568"/>
+        <location filename="mainwindow.cpp" line="1591"/>
         <source>Installing the themes failed (code %1).
 
 %2</source>
@@ -663,13 +663,13 @@ Reinstall the GUI (on SteamOS, re-run install-GUI.sh) to install or restore it, 
 %2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1576"/>
-        <location filename="mainwindow.cpp" line="1583"/>
+        <location filename="mainwindow.cpp" line="1599"/>
+        <location filename="mainwindow.cpp" line="1606"/>
         <source>Theme Randomizer</source>
         <translation>السمة العشوائية</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1591"/>
+        <location filename="mainwindow.cpp" line="1614"/>
         <source>Failed to open %1 in the file manager.</source>
         <translation>تعذّر فتح %1 في مدير الملفات.</translation>
     </message>
@@ -696,22 +696,32 @@ Reinstall the GUI (on SteamOS, re-run install-GUI.sh) to install or restore it, 
 <context>
     <name>PreviewDialog</name>
     <message>
-        <location filename="previewdialog.cpp" line="34"/>
+        <location filename="previewdialog.cpp" line="62"/>
         <source>No boot options selected.</source>
         <translation>لم يتم اختيار أي خيار إقلاع.</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="89"/>
+        <location filename="previewdialog.cpp" line="166"/>
         <source>Preview</source>
         <translation>معاينة</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="101"/>
+        <location filename="previewdialog.cpp" line="181"/>
         <source>Approximate preview — rEFInd&apos;s real rendering also depends on the firmware resolution and theme.</source>
         <translation>معاينة تقريبية — يعتمد العرض الفعلي في rEFInd أيضًا على دقة البرنامج الثابت والسمة.</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="107"/>
+        <location filename="previewdialog.cpp" line="184"/>
+        <source>Approximate preview showing the randomly picked &quot;%1&quot; theme — Random picks a theme anew each time the config is created.</source>
+        <translation>معاينة تقريبية تعرض السمة «%1» المختارة عشوائيًا — «عشوائي» يختار سمة جديدة في كل مرة يتم فيها إنشاء الإعداد.</translation>
+    </message>
+    <message>
+        <location filename="previewdialog.cpp" line="188"/>
+        <source>Approximate preview with the &quot;%1&quot; theme applied — rEFInd&apos;s real rendering also depends on the firmware resolution and the theme&apos;s other settings.</source>
+        <translation>معاينة تقريبية مع تطبيق السمة «%1» — يعتمد العرض الفعلي في rEFInd أيضًا على دقة البرنامج الثابت وبقية إعدادات السمة.</translation>
+    </message>
+    <message>
+        <location filename="previewdialog.cpp" line="197"/>
         <source>Boot screen</source>
         <translation>شاشة الإقلاع</translation>
     </message>

--- a/GUI/src/SteamDeck_rEFInd_bn.ts
+++ b/GUI/src/SteamDeck_rEFInd_bn.ts
@@ -120,7 +120,7 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="468"/>
-        <location filename="mainwindow.cpp" line="1590"/>
+        <location filename="mainwindow.cpp" line="1613"/>
         <source>Open Folder</source>
         <translation>ফোল্ডার খুলুন</translation>
     </message>
@@ -280,9 +280,9 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="965"/>
-        <location filename="mainwindow.cpp" line="1545"/>
-        <location filename="mainwindow.cpp" line="1560"/>
-        <location filename="mainwindow.cpp" line="1565"/>
+        <location filename="mainwindow.cpp" line="1568"/>
+        <location filename="mainwindow.cpp" line="1583"/>
+        <location filename="mainwindow.cpp" line="1588"/>
         <source>Install Themes</source>
         <translation>থিম ইনস্টল</translation>
     </message>
@@ -325,10 +325,10 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="1080"/>
-        <location filename="mainwindow.cpp" line="1086"/>
-        <location filename="mainwindow.cpp" line="1104"/>
-        <location filename="mainwindow.cpp" line="1110"/>
-        <location filename="mainwindow.cpp" line="1115"/>
+        <location filename="mainwindow.cpp" line="1109"/>
+        <location filename="mainwindow.cpp" line="1127"/>
+        <location filename="mainwindow.cpp" line="1133"/>
+        <location filename="mainwindow.cpp" line="1138"/>
         <source>Install Config</source>
         <translation>কনফিগ ইনস্টল</translation>
     </message>
@@ -491,7 +491,7 @@
         <translation>%1 সম্পূর্ণ লেখা যায়নি — ডিস্ক পূর্ণ হয়ে থাকতে পারে। কনফিগারেশন আপডেট হয়নি।</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1087"/>
+        <location filename="mainwindow.cpp" line="1110"/>
         <source>The config-install script was NOT run:
 
 %1
@@ -508,18 +508,18 @@ Reinstall the GUI to restore the original script, then try again.</source>
 মূল স্ক্রিপ্ট ফিরিয়ে আনতে GUI আবার ইনস্টল করুন, তারপর আবার চেষ্টা করুন।</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1105"/>
-        <location filename="mainwindow.cpp" line="1117"/>
+        <location filename="mainwindow.cpp" line="1128"/>
+        <location filename="mainwindow.cpp" line="1140"/>
         <source>Installing the config failed (code %1).</source>
         <translation>কনফিগারেশন ইনস্টল ব্যর্থ হয়েছে (কোড %1)।</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1112"/>
+        <location filename="mainwindow.cpp" line="1135"/>
         <source>The config was installed successfully.</source>
         <translation>কনফিগারেশন সফলভাবে ইনস্টল হয়েছে।</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1113"/>
+        <location filename="mainwindow.cpp" line="1136"/>
         <source>The config was installed successfully.
 
 %1</source>
@@ -528,7 +528,7 @@ Reinstall the GUI to restore the original script, then try again.</source>
 %1</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1118"/>
+        <location filename="mainwindow.cpp" line="1141"/>
         <source>Installing the config failed (code %1).
 
 %2</source>
@@ -537,28 +537,28 @@ Reinstall the GUI to restore the original script, then try again.</source>
 %2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1138"/>
-        <location filename="mainwindow.cpp" line="1148"/>
-        <location filename="mainwindow.cpp" line="1155"/>
+        <location filename="mainwindow.cpp" line="1161"/>
+        <location filename="mainwindow.cpp" line="1171"/>
+        <location filename="mainwindow.cpp" line="1178"/>
         <source>Copy PNG</source>
         <translation>PNG কপি করুন</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="935"/>
         <location filename="mainwindow.cpp" line="944"/>
-        <location filename="mainwindow.cpp" line="1139"/>
-        <location filename="mainwindow.cpp" line="1149"/>
-        <location filename="mainwindow.cpp" line="1156"/>
+        <location filename="mainwindow.cpp" line="1162"/>
+        <location filename="mainwindow.cpp" line="1172"/>
+        <location filename="mainwindow.cpp" line="1179"/>
         <source>Could not copy %1 to %2</source>
         <translation>%1-কে %2-এ কপি করা যায়নি</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1181"/>
+        <location filename="mainwindow.cpp" line="1204"/>
         <source>Invalid PNG</source>
         <translation>অবৈধ PNG</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1182"/>
+        <location filename="mainwindow.cpp" line="1205"/>
         <source>%1 is not a valid PNG file.
 
 Backgrounds and OS icons must be real PNG images (not just files with a .png extension).</source>
@@ -567,58 +567,58 @@ Backgrounds and OS icons must be real PNG images (not just files with a .png ext
 পটভূমি ও OS আইকন অবশ্যই আসল PNG ছবি হতে হবে (শুধু .png এক্সটেনশনের ফাইল নয়)।</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1445"/>
+        <location filename="mainwindow.cpp" line="1468"/>
         <source>Check For Update</source>
         <translation>আপডেট পরীক্ষা করুন</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1448"/>
+        <location filename="mainwindow.cpp" line="1471"/>
         <source>&lt;p align=&apos;center&apos;&gt;&lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd&apos;&gt;rEFInd Customization GUI v%1&lt;/a&gt;&lt;br&gt;&lt;br&gt;Original GUI Creator: &lt;a href=&apos;https://github.com/jlobue10&apos;&gt;jlobue10&lt;/a&gt;&lt;br&gt;&lt;br&gt;Special Thanks to Deck Wizard for testing and QA&lt;br&gt;&lt;br&gt;&lt;a href=&apos;https://www.youtube.com/watch?v=yBHzVSDVEqw&apos;&gt;Deck Wizard Dual Boot Tutorial&lt;/a&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;&lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd&apos;&gt;rEFInd Customization GUI v%1&lt;/a&gt;&lt;br&gt;&lt;br&gt;মূল GUI নির্মাতা: &lt;a href=&apos;https://github.com/jlobue10&apos;&gt;jlobue10&lt;/a&gt;&lt;br&gt;&lt;br&gt;পরীক্ষা ও মান নিশ্চিতকরণের জন্য Deck Wizard-কে বিশেষ ধন্যবাদ&lt;br&gt;&lt;br&gt;&lt;a href=&apos;https://www.youtube.com/watch?v=yBHzVSDVEqw&apos;&gt;Deck Wizard ডুয়াল বুট টিউটোরিয়াল&lt;/a&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1497"/>
+        <location filename="mainwindow.cpp" line="1520"/>
         <source>&lt;p align=&apos;center&apos;&gt;Update check failed. Please check your internet connection and try again.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;আপডেট পরীক্ষা ব্যর্থ হয়েছে। ইন্টারনেট সংযোগ পরীক্ষা করে আবার চেষ্টা করুন।&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1500"/>
+        <location filename="mainwindow.cpp" line="1523"/>
         <source>&lt;p align=&apos;center&apos;&gt;An update is available &lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd/releases&apos;&gt;here&lt;/a&gt;&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;একটি আপডেট &lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd/releases&apos;&gt;এখানে&lt;/a&gt; পাওয়া যাচ্ছে&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1504"/>
+        <location filename="mainwindow.cpp" line="1527"/>
         <source>&lt;p align=&apos;center&apos;&gt;No update found. You are using the latest version.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;কোনো আপডেট পাওয়া যায়নি। আপনি সর্বশেষ সংস্করণ ব্যবহার করছেন।&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1514"/>
-        <location filename="mainwindow.cpp" line="1521"/>
+        <location filename="mainwindow.cpp" line="1537"/>
+        <location filename="mainwindow.cpp" line="1544"/>
         <source>systemd service</source>
         <translation>systemd পরিষেবা</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1515"/>
-        <location filename="mainwindow.cpp" line="1522"/>
+        <location filename="mainwindow.cpp" line="1538"/>
+        <location filename="mainwindow.cpp" line="1545"/>
         <source>Failed to launch the service toggle.</source>
         <translation>পরিষেবা টগল চালু করা যায়নি।</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1528"/>
-        <location filename="mainwindow.cpp" line="1535"/>
+        <location filename="mainwindow.cpp" line="1551"/>
+        <location filename="mainwindow.cpp" line="1558"/>
         <source>Background Randomizer</source>
         <translation>এলোমেলো পটভূমি</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1529"/>
-        <location filename="mainwindow.cpp" line="1536"/>
-        <location filename="mainwindow.cpp" line="1577"/>
-        <location filename="mainwindow.cpp" line="1584"/>
+        <location filename="mainwindow.cpp" line="1552"/>
+        <location filename="mainwindow.cpp" line="1559"/>
+        <location filename="mainwindow.cpp" line="1600"/>
+        <location filename="mainwindow.cpp" line="1607"/>
         <source>Failed to launch the randomizer setup.</source>
         <translation>এলোমেলো পটভূমি সেটআপ চালু করা যায়নি।</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1546"/>
+        <location filename="mainwindow.cpp" line="1569"/>
         <source>The themes-install script was NOT run:
 
 %1
@@ -635,12 +635,12 @@ Reinstall the GUI (on SteamOS, re-run install-GUI.sh) to install or restore it, 
 এটি ইনস্টল বা পুনরুদ্ধার করতে GUI আবার ইনস্টল করুন (SteamOS-এ install-GUI.sh আবার চালান), তারপর আবার চেষ্টা করুন।</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1562"/>
+        <location filename="mainwindow.cpp" line="1585"/>
         <source>The themes were installed successfully.</source>
         <translation>থিমগুলি সফলভাবে ইনস্টল হয়েছে।</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1563"/>
+        <location filename="mainwindow.cpp" line="1586"/>
         <source>The themes were installed successfully.
 
 %1</source>
@@ -649,12 +649,12 @@ Reinstall the GUI (on SteamOS, re-run install-GUI.sh) to install or restore it, 
 %1</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1567"/>
+        <location filename="mainwindow.cpp" line="1590"/>
         <source>Installing the themes failed (code %1).</source>
         <translation>থিম ইনস্টল ব্যর্থ হয়েছে (কোড %1)।</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1568"/>
+        <location filename="mainwindow.cpp" line="1591"/>
         <source>Installing the themes failed (code %1).
 
 %2</source>
@@ -663,13 +663,13 @@ Reinstall the GUI (on SteamOS, re-run install-GUI.sh) to install or restore it, 
 %2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1576"/>
-        <location filename="mainwindow.cpp" line="1583"/>
+        <location filename="mainwindow.cpp" line="1599"/>
+        <location filename="mainwindow.cpp" line="1606"/>
         <source>Theme Randomizer</source>
         <translation>এলোমেলো থিম</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1591"/>
+        <location filename="mainwindow.cpp" line="1614"/>
         <source>Failed to open %1 in the file manager.</source>
         <translation>ফাইল ব্যবস্থাপকে %1 খোলা যায়নি।</translation>
     </message>
@@ -696,22 +696,32 @@ Reinstall the GUI (on SteamOS, re-run install-GUI.sh) to install or restore it, 
 <context>
     <name>PreviewDialog</name>
     <message>
-        <location filename="previewdialog.cpp" line="34"/>
+        <location filename="previewdialog.cpp" line="62"/>
         <source>No boot options selected.</source>
         <translation>কোনো বুট বিকল্প নির্বাচিত নেই।</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="89"/>
+        <location filename="previewdialog.cpp" line="166"/>
         <source>Preview</source>
         <translation>প্রিভিউ</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="101"/>
+        <location filename="previewdialog.cpp" line="181"/>
         <source>Approximate preview — rEFInd&apos;s real rendering also depends on the firmware resolution and theme.</source>
         <translation>আনুমানিক প্রিভিউ — rEFInd-এর প্রকৃত প্রদর্শন ফার্মওয়্যার রেজোলিউশন ও থিমের উপরও নির্ভর করে।</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="107"/>
+        <location filename="previewdialog.cpp" line="184"/>
+        <source>Approximate preview showing the randomly picked &quot;%1&quot; theme — Random picks a theme anew each time the config is created.</source>
+        <translation>এলোমেলোভাবে বাছাই করা &quot;%1&quot; থিম দেখানো আনুমানিক প্রিভিউ — &quot;এলোমেলো&quot; প্রতিবার কনফিগ তৈরির সময় নতুন একটি থিম বেছে নেয়।</translation>
+    </message>
+    <message>
+        <location filename="previewdialog.cpp" line="188"/>
+        <source>Approximate preview with the &quot;%1&quot; theme applied — rEFInd&apos;s real rendering also depends on the firmware resolution and the theme&apos;s other settings.</source>
+        <translation>&quot;%1&quot; থিম প্রয়োগ করা আনুমানিক প্রিভিউ — rEFInd-এর প্রকৃত প্রদর্শন ফার্মওয়্যার রেজোলিউশন ও থিমের অন্যান্য সেটিংসের উপরও নির্ভর করে।</translation>
+    </message>
+    <message>
+        <location filename="previewdialog.cpp" line="197"/>
         <source>Boot screen</source>
         <translation>বুট স্ক্রিন</translation>
     </message>

--- a/GUI/src/SteamDeck_rEFInd_de.ts
+++ b/GUI/src/SteamDeck_rEFInd_de.ts
@@ -120,7 +120,7 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="468"/>
-        <location filename="mainwindow.cpp" line="1590"/>
+        <location filename="mainwindow.cpp" line="1613"/>
         <source>Open Folder</source>
         <translation>Ordner öffnen</translation>
     </message>
@@ -280,9 +280,9 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="965"/>
-        <location filename="mainwindow.cpp" line="1545"/>
-        <location filename="mainwindow.cpp" line="1560"/>
-        <location filename="mainwindow.cpp" line="1565"/>
+        <location filename="mainwindow.cpp" line="1568"/>
+        <location filename="mainwindow.cpp" line="1583"/>
+        <location filename="mainwindow.cpp" line="1588"/>
         <source>Install Themes</source>
         <translation>Themen installieren</translation>
     </message>
@@ -325,10 +325,10 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="1080"/>
-        <location filename="mainwindow.cpp" line="1086"/>
-        <location filename="mainwindow.cpp" line="1104"/>
-        <location filename="mainwindow.cpp" line="1110"/>
-        <location filename="mainwindow.cpp" line="1115"/>
+        <location filename="mainwindow.cpp" line="1109"/>
+        <location filename="mainwindow.cpp" line="1127"/>
+        <location filename="mainwindow.cpp" line="1133"/>
+        <location filename="mainwindow.cpp" line="1138"/>
         <source>Install Config</source>
         <translation>Konfig installieren</translation>
     </message>
@@ -491,7 +491,7 @@
         <translation>%1 konnte nicht vollständig geschrieben werden — das Laufwerk ist möglicherweise voll. Die Konfiguration wurde nicht aktualisiert.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1087"/>
+        <location filename="mainwindow.cpp" line="1110"/>
         <source>The config-install script was NOT run:
 
 %1
@@ -508,18 +508,18 @@ Es stimmt nicht mit der Kopie überein, die mit dieser Version der App ausgelief
 Installieren Sie die GUI neu, um das Originalskript wiederherzustellen, und versuchen Sie es erneut.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1105"/>
-        <location filename="mainwindow.cpp" line="1117"/>
+        <location filename="mainwindow.cpp" line="1128"/>
+        <location filename="mainwindow.cpp" line="1140"/>
         <source>Installing the config failed (code %1).</source>
         <translation>Die Installation der Konfiguration ist fehlgeschlagen (Code %1).</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1112"/>
+        <location filename="mainwindow.cpp" line="1135"/>
         <source>The config was installed successfully.</source>
         <translation>Die Konfiguration wurde erfolgreich installiert.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1113"/>
+        <location filename="mainwindow.cpp" line="1136"/>
         <source>The config was installed successfully.
 
 %1</source>
@@ -528,7 +528,7 @@ Installieren Sie die GUI neu, um das Originalskript wiederherzustellen, und vers
 %1</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1118"/>
+        <location filename="mainwindow.cpp" line="1141"/>
         <source>Installing the config failed (code %1).
 
 %2</source>
@@ -537,28 +537,28 @@ Installieren Sie die GUI neu, um das Originalskript wiederherzustellen, und vers
 %2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1138"/>
-        <location filename="mainwindow.cpp" line="1148"/>
-        <location filename="mainwindow.cpp" line="1155"/>
+        <location filename="mainwindow.cpp" line="1161"/>
+        <location filename="mainwindow.cpp" line="1171"/>
+        <location filename="mainwindow.cpp" line="1178"/>
         <source>Copy PNG</source>
         <translation>PNG kopieren</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="935"/>
         <location filename="mainwindow.cpp" line="944"/>
-        <location filename="mainwindow.cpp" line="1139"/>
-        <location filename="mainwindow.cpp" line="1149"/>
-        <location filename="mainwindow.cpp" line="1156"/>
+        <location filename="mainwindow.cpp" line="1162"/>
+        <location filename="mainwindow.cpp" line="1172"/>
+        <location filename="mainwindow.cpp" line="1179"/>
         <source>Could not copy %1 to %2</source>
         <translation>%1 konnte nicht nach %2 kopiert werden</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1181"/>
+        <location filename="mainwindow.cpp" line="1204"/>
         <source>Invalid PNG</source>
         <translation>Ungültiges PNG</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1182"/>
+        <location filename="mainwindow.cpp" line="1205"/>
         <source>%1 is not a valid PNG file.
 
 Backgrounds and OS icons must be real PNG images (not just files with a .png extension).</source>
@@ -567,58 +567,58 @@ Backgrounds and OS icons must be real PNG images (not just files with a .png ext
 Hintergründe und OS-Symbole müssen echte PNG-Bilder sein (nicht nur Dateien mit der Endung .png).</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1445"/>
+        <location filename="mainwindow.cpp" line="1468"/>
         <source>Check For Update</source>
         <translation>Auf Updates prüfen</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1448"/>
+        <location filename="mainwindow.cpp" line="1471"/>
         <source>&lt;p align=&apos;center&apos;&gt;&lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd&apos;&gt;rEFInd Customization GUI v%1&lt;/a&gt;&lt;br&gt;&lt;br&gt;Original GUI Creator: &lt;a href=&apos;https://github.com/jlobue10&apos;&gt;jlobue10&lt;/a&gt;&lt;br&gt;&lt;br&gt;Special Thanks to Deck Wizard for testing and QA&lt;br&gt;&lt;br&gt;&lt;a href=&apos;https://www.youtube.com/watch?v=yBHzVSDVEqw&apos;&gt;Deck Wizard Dual Boot Tutorial&lt;/a&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;&lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd&apos;&gt;rEFInd Customization GUI v%1&lt;/a&gt;&lt;br&gt;&lt;br&gt;Ursprünglicher GUI-Entwickler: &lt;a href=&apos;https://github.com/jlobue10&apos;&gt;jlobue10&lt;/a&gt;&lt;br&gt;&lt;br&gt;Besonderer Dank an Deck Wizard für Tests und QA&lt;br&gt;&lt;br&gt;&lt;a href=&apos;https://www.youtube.com/watch?v=yBHzVSDVEqw&apos;&gt;Dual-Boot-Tutorial von Deck Wizard&lt;/a&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1497"/>
+        <location filename="mainwindow.cpp" line="1520"/>
         <source>&lt;p align=&apos;center&apos;&gt;Update check failed. Please check your internet connection and try again.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;Update-Prüfung fehlgeschlagen. Bitte prüfen Sie Ihre Internetverbindung und versuchen Sie es erneut.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1500"/>
+        <location filename="mainwindow.cpp" line="1523"/>
         <source>&lt;p align=&apos;center&apos;&gt;An update is available &lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd/releases&apos;&gt;here&lt;/a&gt;&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;Ein Update ist &lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd/releases&apos;&gt;hier&lt;/a&gt; verfügbar&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1504"/>
+        <location filename="mainwindow.cpp" line="1527"/>
         <source>&lt;p align=&apos;center&apos;&gt;No update found. You are using the latest version.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;Kein Update gefunden. Sie verwenden die neueste Version.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1514"/>
-        <location filename="mainwindow.cpp" line="1521"/>
+        <location filename="mainwindow.cpp" line="1537"/>
+        <location filename="mainwindow.cpp" line="1544"/>
         <source>systemd service</source>
         <translation>systemd-Dienst</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1515"/>
-        <location filename="mainwindow.cpp" line="1522"/>
+        <location filename="mainwindow.cpp" line="1538"/>
+        <location filename="mainwindow.cpp" line="1545"/>
         <source>Failed to launch the service toggle.</source>
         <translation>Das Umschalten des Dienstes konnte nicht gestartet werden.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1528"/>
-        <location filename="mainwindow.cpp" line="1535"/>
+        <location filename="mainwindow.cpp" line="1551"/>
+        <location filename="mainwindow.cpp" line="1558"/>
         <source>Background Randomizer</source>
         <translation>Hintergrund-Zufallswechsel</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1529"/>
-        <location filename="mainwindow.cpp" line="1536"/>
-        <location filename="mainwindow.cpp" line="1577"/>
-        <location filename="mainwindow.cpp" line="1584"/>
+        <location filename="mainwindow.cpp" line="1552"/>
+        <location filename="mainwindow.cpp" line="1559"/>
+        <location filename="mainwindow.cpp" line="1600"/>
+        <location filename="mainwindow.cpp" line="1607"/>
         <source>Failed to launch the randomizer setup.</source>
         <translation>Die Einrichtung des Zufallswechsels konnte nicht gestartet werden.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1546"/>
+        <location filename="mainwindow.cpp" line="1569"/>
         <source>The themes-install script was NOT run:
 
 %1
@@ -635,12 +635,12 @@ Es fehlt, oder es stimmt nicht mit der Kopie überein, die mit dieser Version de
 Installieren Sie die GUI neu (auf SteamOS: install-GUI.sh erneut ausführen), um es zu installieren oder wiederherzustellen, und versuchen Sie es erneut.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1562"/>
+        <location filename="mainwindow.cpp" line="1585"/>
         <source>The themes were installed successfully.</source>
         <translation>Die Themen wurden erfolgreich installiert.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1563"/>
+        <location filename="mainwindow.cpp" line="1586"/>
         <source>The themes were installed successfully.
 
 %1</source>
@@ -649,12 +649,12 @@ Installieren Sie die GUI neu (auf SteamOS: install-GUI.sh erneut ausführen), um
 %1</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1567"/>
+        <location filename="mainwindow.cpp" line="1590"/>
         <source>Installing the themes failed (code %1).</source>
         <translation>Die Installation der Themen ist fehlgeschlagen (Code %1).</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1568"/>
+        <location filename="mainwindow.cpp" line="1591"/>
         <source>Installing the themes failed (code %1).
 
 %2</source>
@@ -663,13 +663,13 @@ Installieren Sie die GUI neu (auf SteamOS: install-GUI.sh erneut ausführen), um
 %2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1576"/>
-        <location filename="mainwindow.cpp" line="1583"/>
+        <location filename="mainwindow.cpp" line="1599"/>
+        <location filename="mainwindow.cpp" line="1606"/>
         <source>Theme Randomizer</source>
         <translation>Themen-Zufallswechsel</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1591"/>
+        <location filename="mainwindow.cpp" line="1614"/>
         <source>Failed to open %1 in the file manager.</source>
         <translation>%1 konnte nicht im Dateimanager geöffnet werden.</translation>
     </message>
@@ -696,22 +696,32 @@ Installieren Sie die GUI neu (auf SteamOS: install-GUI.sh erneut ausführen), um
 <context>
     <name>PreviewDialog</name>
     <message>
-        <location filename="previewdialog.cpp" line="34"/>
+        <location filename="previewdialog.cpp" line="62"/>
         <source>No boot options selected.</source>
         <translation>Keine Boot-Optionen ausgewählt.</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="89"/>
+        <location filename="previewdialog.cpp" line="166"/>
         <source>Preview</source>
         <translation>Vorschau</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="101"/>
+        <location filename="previewdialog.cpp" line="181"/>
         <source>Approximate preview — rEFInd&apos;s real rendering also depends on the firmware resolution and theme.</source>
         <translation>Ungefähre Vorschau — die tatsächliche Darstellung von rEFInd hängt auch von der Firmware-Auflösung und dem Theme ab.</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="107"/>
+        <location filename="previewdialog.cpp" line="184"/>
+        <source>Approximate preview showing the randomly picked &quot;%1&quot; theme — Random picks a theme anew each time the config is created.</source>
+        <translation>Ungefähre Vorschau mit dem zufällig gewählten Theme „%1“ — „Zufällig“ wählt bei jedem Erstellen der Konfiguration ein neues Theme aus.</translation>
+    </message>
+    <message>
+        <location filename="previewdialog.cpp" line="188"/>
+        <source>Approximate preview with the &quot;%1&quot; theme applied — rEFInd&apos;s real rendering also depends on the firmware resolution and the theme&apos;s other settings.</source>
+        <translation>Ungefähre Vorschau mit angewendetem Theme „%1“ — die tatsächliche Darstellung von rEFInd hängt auch von der Firmware-Auflösung und den übrigen Einstellungen des Themes ab.</translation>
+    </message>
+    <message>
+        <location filename="previewdialog.cpp" line="197"/>
         <source>Boot screen</source>
         <translation>Bootbildschirm</translation>
     </message>

--- a/GUI/src/SteamDeck_rEFInd_en_US.ts
+++ b/GUI/src/SteamDeck_rEFInd_en_US.ts
@@ -120,7 +120,7 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="468"/>
-        <location filename="mainwindow.cpp" line="1590"/>
+        <location filename="mainwindow.cpp" line="1613"/>
         <source>Open Folder</source>
         <translation type="unfinished"></translation>
     </message>
@@ -276,9 +276,9 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="965"/>
-        <location filename="mainwindow.cpp" line="1545"/>
-        <location filename="mainwindow.cpp" line="1560"/>
-        <location filename="mainwindow.cpp" line="1565"/>
+        <location filename="mainwindow.cpp" line="1568"/>
+        <location filename="mainwindow.cpp" line="1583"/>
+        <location filename="mainwindow.cpp" line="1588"/>
         <source>Install Themes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -321,10 +321,10 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="1080"/>
-        <location filename="mainwindow.cpp" line="1086"/>
-        <location filename="mainwindow.cpp" line="1104"/>
-        <location filename="mainwindow.cpp" line="1110"/>
-        <location filename="mainwindow.cpp" line="1115"/>
+        <location filename="mainwindow.cpp" line="1109"/>
+        <location filename="mainwindow.cpp" line="1127"/>
+        <location filename="mainwindow.cpp" line="1133"/>
+        <location filename="mainwindow.cpp" line="1138"/>
         <source>Install Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -487,7 +487,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1087"/>
+        <location filename="mainwindow.cpp" line="1110"/>
         <source>The config-install script was NOT run:
 
 %1
@@ -498,111 +498,111 @@ Reinstall the GUI to restore the original script, then try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1105"/>
-        <location filename="mainwindow.cpp" line="1117"/>
+        <location filename="mainwindow.cpp" line="1128"/>
+        <location filename="mainwindow.cpp" line="1140"/>
         <source>Installing the config failed (code %1).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1112"/>
+        <location filename="mainwindow.cpp" line="1135"/>
         <source>The config was installed successfully.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1113"/>
+        <location filename="mainwindow.cpp" line="1136"/>
         <source>The config was installed successfully.
 
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1118"/>
+        <location filename="mainwindow.cpp" line="1141"/>
         <source>Installing the config failed (code %1).
 
 %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1138"/>
-        <location filename="mainwindow.cpp" line="1148"/>
-        <location filename="mainwindow.cpp" line="1155"/>
+        <location filename="mainwindow.cpp" line="1161"/>
+        <location filename="mainwindow.cpp" line="1171"/>
+        <location filename="mainwindow.cpp" line="1178"/>
         <source>Copy PNG</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="935"/>
         <location filename="mainwindow.cpp" line="944"/>
-        <location filename="mainwindow.cpp" line="1139"/>
-        <location filename="mainwindow.cpp" line="1149"/>
-        <location filename="mainwindow.cpp" line="1156"/>
+        <location filename="mainwindow.cpp" line="1162"/>
+        <location filename="mainwindow.cpp" line="1172"/>
+        <location filename="mainwindow.cpp" line="1179"/>
         <source>Could not copy %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1181"/>
+        <location filename="mainwindow.cpp" line="1204"/>
         <source>Invalid PNG</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1182"/>
+        <location filename="mainwindow.cpp" line="1205"/>
         <source>%1 is not a valid PNG file.
 
 Backgrounds and OS icons must be real PNG images (not just files with a .png extension).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1445"/>
+        <location filename="mainwindow.cpp" line="1468"/>
         <source>Check For Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1448"/>
+        <location filename="mainwindow.cpp" line="1471"/>
         <source>&lt;p align=&apos;center&apos;&gt;&lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd&apos;&gt;rEFInd Customization GUI v%1&lt;/a&gt;&lt;br&gt;&lt;br&gt;Original GUI Creator: &lt;a href=&apos;https://github.com/jlobue10&apos;&gt;jlobue10&lt;/a&gt;&lt;br&gt;&lt;br&gt;Special Thanks to Deck Wizard for testing and QA&lt;br&gt;&lt;br&gt;&lt;a href=&apos;https://www.youtube.com/watch?v=yBHzVSDVEqw&apos;&gt;Deck Wizard Dual Boot Tutorial&lt;/a&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1497"/>
+        <location filename="mainwindow.cpp" line="1520"/>
         <source>&lt;p align=&apos;center&apos;&gt;Update check failed. Please check your internet connection and try again.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1500"/>
+        <location filename="mainwindow.cpp" line="1523"/>
         <source>&lt;p align=&apos;center&apos;&gt;An update is available &lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd/releases&apos;&gt;here&lt;/a&gt;&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1504"/>
+        <location filename="mainwindow.cpp" line="1527"/>
         <source>&lt;p align=&apos;center&apos;&gt;No update found. You are using the latest version.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1514"/>
-        <location filename="mainwindow.cpp" line="1521"/>
+        <location filename="mainwindow.cpp" line="1537"/>
+        <location filename="mainwindow.cpp" line="1544"/>
         <source>systemd service</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1515"/>
-        <location filename="mainwindow.cpp" line="1522"/>
+        <location filename="mainwindow.cpp" line="1538"/>
+        <location filename="mainwindow.cpp" line="1545"/>
         <source>Failed to launch the service toggle.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1528"/>
-        <location filename="mainwindow.cpp" line="1535"/>
+        <location filename="mainwindow.cpp" line="1551"/>
+        <location filename="mainwindow.cpp" line="1558"/>
         <source>Background Randomizer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1529"/>
-        <location filename="mainwindow.cpp" line="1536"/>
-        <location filename="mainwindow.cpp" line="1577"/>
-        <location filename="mainwindow.cpp" line="1584"/>
+        <location filename="mainwindow.cpp" line="1552"/>
+        <location filename="mainwindow.cpp" line="1559"/>
+        <location filename="mainwindow.cpp" line="1600"/>
+        <location filename="mainwindow.cpp" line="1607"/>
         <source>Failed to launch the randomizer setup.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1546"/>
+        <location filename="mainwindow.cpp" line="1569"/>
         <source>The themes-install script was NOT run:
 
 %1
@@ -613,37 +613,37 @@ Reinstall the GUI (on SteamOS, re-run install-GUI.sh) to install or restore it, 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1562"/>
+        <location filename="mainwindow.cpp" line="1585"/>
         <source>The themes were installed successfully.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1563"/>
+        <location filename="mainwindow.cpp" line="1586"/>
         <source>The themes were installed successfully.
 
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1567"/>
+        <location filename="mainwindow.cpp" line="1590"/>
         <source>Installing the themes failed (code %1).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1568"/>
+        <location filename="mainwindow.cpp" line="1591"/>
         <source>Installing the themes failed (code %1).
 
 %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1576"/>
-        <location filename="mainwindow.cpp" line="1583"/>
+        <location filename="mainwindow.cpp" line="1599"/>
+        <location filename="mainwindow.cpp" line="1606"/>
         <source>Theme Randomizer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1591"/>
+        <location filename="mainwindow.cpp" line="1614"/>
         <source>Failed to open %1 in the file manager.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -670,22 +670,32 @@ Reinstall the GUI (on SteamOS, re-run install-GUI.sh) to install or restore it, 
 <context>
     <name>PreviewDialog</name>
     <message>
-        <location filename="previewdialog.cpp" line="34"/>
+        <location filename="previewdialog.cpp" line="62"/>
         <source>No boot options selected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="89"/>
+        <location filename="previewdialog.cpp" line="166"/>
         <source>Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="101"/>
+        <location filename="previewdialog.cpp" line="181"/>
         <source>Approximate preview — rEFInd&apos;s real rendering also depends on the firmware resolution and theme.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="107"/>
+        <location filename="previewdialog.cpp" line="184"/>
+        <source>Approximate preview showing the randomly picked &quot;%1&quot; theme — Random picks a theme anew each time the config is created.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="previewdialog.cpp" line="188"/>
+        <source>Approximate preview with the &quot;%1&quot; theme applied — rEFInd&apos;s real rendering also depends on the firmware resolution and the theme&apos;s other settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="previewdialog.cpp" line="197"/>
         <source>Boot screen</source>
         <translation type="unfinished"></translation>
     </message>

--- a/GUI/src/SteamDeck_rEFInd_es.ts
+++ b/GUI/src/SteamDeck_rEFInd_es.ts
@@ -120,7 +120,7 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="468"/>
-        <location filename="mainwindow.cpp" line="1590"/>
+        <location filename="mainwindow.cpp" line="1613"/>
         <source>Open Folder</source>
         <translation>Abrir carpeta</translation>
     </message>
@@ -280,9 +280,9 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="965"/>
-        <location filename="mainwindow.cpp" line="1545"/>
-        <location filename="mainwindow.cpp" line="1560"/>
-        <location filename="mainwindow.cpp" line="1565"/>
+        <location filename="mainwindow.cpp" line="1568"/>
+        <location filename="mainwindow.cpp" line="1583"/>
+        <location filename="mainwindow.cpp" line="1588"/>
         <source>Install Themes</source>
         <translation>Instalar temas</translation>
     </message>
@@ -325,10 +325,10 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="1080"/>
-        <location filename="mainwindow.cpp" line="1086"/>
-        <location filename="mainwindow.cpp" line="1104"/>
-        <location filename="mainwindow.cpp" line="1110"/>
-        <location filename="mainwindow.cpp" line="1115"/>
+        <location filename="mainwindow.cpp" line="1109"/>
+        <location filename="mainwindow.cpp" line="1127"/>
+        <location filename="mainwindow.cpp" line="1133"/>
+        <location filename="mainwindow.cpp" line="1138"/>
         <source>Install Config</source>
         <translation>Instalar config.</translation>
     </message>
@@ -491,7 +491,7 @@
         <translation>No se pudo escribir %1 por completo — puede que el disco esté lleno. La configuración no se actualizó.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1087"/>
+        <location filename="mainwindow.cpp" line="1110"/>
         <source>The config-install script was NOT run:
 
 %1
@@ -508,18 +508,18 @@ No coincide con la copia incluida en esta versión de la aplicación. Como se ej
 Reinstale la GUI para restaurar el script original y vuelva a intentarlo.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1105"/>
-        <location filename="mainwindow.cpp" line="1117"/>
+        <location filename="mainwindow.cpp" line="1128"/>
+        <location filename="mainwindow.cpp" line="1140"/>
         <source>Installing the config failed (code %1).</source>
         <translation>La instalación de la configuración falló (código %1).</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1112"/>
+        <location filename="mainwindow.cpp" line="1135"/>
         <source>The config was installed successfully.</source>
         <translation>La configuración se instaló correctamente.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1113"/>
+        <location filename="mainwindow.cpp" line="1136"/>
         <source>The config was installed successfully.
 
 %1</source>
@@ -528,7 +528,7 @@ Reinstale la GUI para restaurar el script original y vuelva a intentarlo.</trans
 %1</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1118"/>
+        <location filename="mainwindow.cpp" line="1141"/>
         <source>Installing the config failed (code %1).
 
 %2</source>
@@ -537,28 +537,28 @@ Reinstale la GUI para restaurar el script original y vuelva a intentarlo.</trans
 %2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1138"/>
-        <location filename="mainwindow.cpp" line="1148"/>
-        <location filename="mainwindow.cpp" line="1155"/>
+        <location filename="mainwindow.cpp" line="1161"/>
+        <location filename="mainwindow.cpp" line="1171"/>
+        <location filename="mainwindow.cpp" line="1178"/>
         <source>Copy PNG</source>
         <translation>Copiar PNG</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="935"/>
         <location filename="mainwindow.cpp" line="944"/>
-        <location filename="mainwindow.cpp" line="1139"/>
-        <location filename="mainwindow.cpp" line="1149"/>
-        <location filename="mainwindow.cpp" line="1156"/>
+        <location filename="mainwindow.cpp" line="1162"/>
+        <location filename="mainwindow.cpp" line="1172"/>
+        <location filename="mainwindow.cpp" line="1179"/>
         <source>Could not copy %1 to %2</source>
         <translation>No se pudo copiar %1 a %2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1181"/>
+        <location filename="mainwindow.cpp" line="1204"/>
         <source>Invalid PNG</source>
         <translation>PNG no válido</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1182"/>
+        <location filename="mainwindow.cpp" line="1205"/>
         <source>%1 is not a valid PNG file.
 
 Backgrounds and OS icons must be real PNG images (not just files with a .png extension).</source>
@@ -567,58 +567,58 @@ Backgrounds and OS icons must be real PNG images (not just files with a .png ext
 Los fondos y los iconos de SO deben ser imágenes PNG reales (no solo archivos con extensión .png).</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1445"/>
+        <location filename="mainwindow.cpp" line="1468"/>
         <source>Check For Update</source>
         <translation>Buscar actualización</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1448"/>
+        <location filename="mainwindow.cpp" line="1471"/>
         <source>&lt;p align=&apos;center&apos;&gt;&lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd&apos;&gt;rEFInd Customization GUI v%1&lt;/a&gt;&lt;br&gt;&lt;br&gt;Original GUI Creator: &lt;a href=&apos;https://github.com/jlobue10&apos;&gt;jlobue10&lt;/a&gt;&lt;br&gt;&lt;br&gt;Special Thanks to Deck Wizard for testing and QA&lt;br&gt;&lt;br&gt;&lt;a href=&apos;https://www.youtube.com/watch?v=yBHzVSDVEqw&apos;&gt;Deck Wizard Dual Boot Tutorial&lt;/a&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;&lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd&apos;&gt;rEFInd Customization GUI v%1&lt;/a&gt;&lt;br&gt;&lt;br&gt;Creador original de la GUI: &lt;a href=&apos;https://github.com/jlobue10&apos;&gt;jlobue10&lt;/a&gt;&lt;br&gt;&lt;br&gt;Agradecimiento especial a Deck Wizard por las pruebas y el control de calidad&lt;br&gt;&lt;br&gt;&lt;a href=&apos;https://www.youtube.com/watch?v=yBHzVSDVEqw&apos;&gt;Tutorial de arranque dual de Deck Wizard&lt;/a&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1497"/>
+        <location filename="mainwindow.cpp" line="1520"/>
         <source>&lt;p align=&apos;center&apos;&gt;Update check failed. Please check your internet connection and try again.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;La comprobación de actualizaciones falló. Compruebe su conexión a Internet y vuelva a intentarlo.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1500"/>
+        <location filename="mainwindow.cpp" line="1523"/>
         <source>&lt;p align=&apos;center&apos;&gt;An update is available &lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd/releases&apos;&gt;here&lt;/a&gt;&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;Hay una actualización disponible &lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd/releases&apos;&gt;aquí&lt;/a&gt;&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1504"/>
+        <location filename="mainwindow.cpp" line="1527"/>
         <source>&lt;p align=&apos;center&apos;&gt;No update found. You are using the latest version.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;No hay actualizaciones. Está usando la versión más reciente.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1514"/>
-        <location filename="mainwindow.cpp" line="1521"/>
+        <location filename="mainwindow.cpp" line="1537"/>
+        <location filename="mainwindow.cpp" line="1544"/>
         <source>systemd service</source>
         <translation>Servicio systemd</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1515"/>
-        <location filename="mainwindow.cpp" line="1522"/>
+        <location filename="mainwindow.cpp" line="1538"/>
+        <location filename="mainwindow.cpp" line="1545"/>
         <source>Failed to launch the service toggle.</source>
         <translation>No se pudo iniciar el cambio del servicio.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1528"/>
-        <location filename="mainwindow.cpp" line="1535"/>
+        <location filename="mainwindow.cpp" line="1551"/>
+        <location filename="mainwindow.cpp" line="1558"/>
         <source>Background Randomizer</source>
         <translation>Fondo aleatorio</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1529"/>
-        <location filename="mainwindow.cpp" line="1536"/>
-        <location filename="mainwindow.cpp" line="1577"/>
-        <location filename="mainwindow.cpp" line="1584"/>
+        <location filename="mainwindow.cpp" line="1552"/>
+        <location filename="mainwindow.cpp" line="1559"/>
+        <location filename="mainwindow.cpp" line="1600"/>
+        <location filename="mainwindow.cpp" line="1607"/>
         <source>Failed to launch the randomizer setup.</source>
         <translation>No se pudo iniciar la configuración del fondo aleatorio.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1546"/>
+        <location filename="mainwindow.cpp" line="1569"/>
         <source>The themes-install script was NOT run:
 
 %1
@@ -635,12 +635,12 @@ Falta, o no coincide con la copia incluida en esta versión de la aplicación. C
 Reinstale la GUI (en SteamOS, vuelva a ejecutar install-GUI.sh) para instalarlo o restaurarlo y vuelva a intentarlo.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1562"/>
+        <location filename="mainwindow.cpp" line="1585"/>
         <source>The themes were installed successfully.</source>
         <translation>Los temas se instalaron correctamente.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1563"/>
+        <location filename="mainwindow.cpp" line="1586"/>
         <source>The themes were installed successfully.
 
 %1</source>
@@ -649,12 +649,12 @@ Reinstale la GUI (en SteamOS, vuelva a ejecutar install-GUI.sh) para instalarlo 
 %1</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1567"/>
+        <location filename="mainwindow.cpp" line="1590"/>
         <source>Installing the themes failed (code %1).</source>
         <translation>La instalación de los temas falló (código %1).</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1568"/>
+        <location filename="mainwindow.cpp" line="1591"/>
         <source>Installing the themes failed (code %1).
 
 %2</source>
@@ -663,13 +663,13 @@ Reinstale la GUI (en SteamOS, vuelva a ejecutar install-GUI.sh) para instalarlo 
 %2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1576"/>
-        <location filename="mainwindow.cpp" line="1583"/>
+        <location filename="mainwindow.cpp" line="1599"/>
+        <location filename="mainwindow.cpp" line="1606"/>
         <source>Theme Randomizer</source>
         <translation>Tema aleatorio</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1591"/>
+        <location filename="mainwindow.cpp" line="1614"/>
         <source>Failed to open %1 in the file manager.</source>
         <translation>No se pudo abrir %1 en el gestor de archivos.</translation>
     </message>
@@ -696,22 +696,32 @@ Reinstale la GUI (en SteamOS, vuelva a ejecutar install-GUI.sh) para instalarlo 
 <context>
     <name>PreviewDialog</name>
     <message>
-        <location filename="previewdialog.cpp" line="34"/>
+        <location filename="previewdialog.cpp" line="62"/>
         <source>No boot options selected.</source>
         <translation>No hay opciones de arranque seleccionadas.</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="89"/>
+        <location filename="previewdialog.cpp" line="166"/>
         <source>Preview</source>
         <translation>Vista previa</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="101"/>
+        <location filename="previewdialog.cpp" line="181"/>
         <source>Approximate preview — rEFInd&apos;s real rendering also depends on the firmware resolution and theme.</source>
         <translation>Vista previa aproximada — la representación real de rEFInd también depende de la resolución del firmware y del tema.</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="107"/>
+        <location filename="previewdialog.cpp" line="184"/>
+        <source>Approximate preview showing the randomly picked &quot;%1&quot; theme — Random picks a theme anew each time the config is created.</source>
+        <translation>Vista previa aproximada mostrando el tema «%1» elegido al azar — «Aleatorio» elige un tema nuevo cada vez que se crea la configuración.</translation>
+    </message>
+    <message>
+        <location filename="previewdialog.cpp" line="188"/>
+        <source>Approximate preview with the &quot;%1&quot; theme applied — rEFInd&apos;s real rendering also depends on the firmware resolution and the theme&apos;s other settings.</source>
+        <translation>Vista previa aproximada con el tema «%1» aplicado — la representación real de rEFInd también depende de la resolución del firmware y de los demás ajustes del tema.</translation>
+    </message>
+    <message>
+        <location filename="previewdialog.cpp" line="197"/>
         <source>Boot screen</source>
         <translation>Pantalla de arranque</translation>
     </message>

--- a/GUI/src/SteamDeck_rEFInd_fa.ts
+++ b/GUI/src/SteamDeck_rEFInd_fa.ts
@@ -120,7 +120,7 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="468"/>
-        <location filename="mainwindow.cpp" line="1590"/>
+        <location filename="mainwindow.cpp" line="1613"/>
         <source>Open Folder</source>
         <translation>باز کردن پوشه</translation>
     </message>
@@ -280,9 +280,9 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="965"/>
-        <location filename="mainwindow.cpp" line="1545"/>
-        <location filename="mainwindow.cpp" line="1560"/>
-        <location filename="mainwindow.cpp" line="1565"/>
+        <location filename="mainwindow.cpp" line="1568"/>
+        <location filename="mainwindow.cpp" line="1583"/>
+        <location filename="mainwindow.cpp" line="1588"/>
         <source>Install Themes</source>
         <translation>نصب تم‌ها</translation>
     </message>
@@ -325,10 +325,10 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="1080"/>
-        <location filename="mainwindow.cpp" line="1086"/>
-        <location filename="mainwindow.cpp" line="1104"/>
-        <location filename="mainwindow.cpp" line="1110"/>
-        <location filename="mainwindow.cpp" line="1115"/>
+        <location filename="mainwindow.cpp" line="1109"/>
+        <location filename="mainwindow.cpp" line="1127"/>
+        <location filename="mainwindow.cpp" line="1133"/>
+        <location filename="mainwindow.cpp" line="1138"/>
         <source>Install Config</source>
         <translation>نصب پیکربندی</translation>
     </message>
@@ -491,7 +491,7 @@
         <translation>نوشتن کامل %1 ممکن نشد — شاید دیسک پر باشد. پیکربندی به‌روزرسانی نشد.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1087"/>
+        <location filename="mainwindow.cpp" line="1110"/>
         <source>The config-install script was NOT run:
 
 %1
@@ -508,18 +508,18 @@ Reinstall the GUI to restore the original script, then try again.</source>
 برای بازگرداندن اسکریپت اصلی، رابط کاربری را دوباره نصب کنید و بعد دوباره تلاش کنید.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1105"/>
-        <location filename="mainwindow.cpp" line="1117"/>
+        <location filename="mainwindow.cpp" line="1128"/>
+        <location filename="mainwindow.cpp" line="1140"/>
         <source>Installing the config failed (code %1).</source>
         <translation>نصب پیکربندی ناموفق بود (کد %1).</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1112"/>
+        <location filename="mainwindow.cpp" line="1135"/>
         <source>The config was installed successfully.</source>
         <translation>پیکربندی با موفقیت نصب شد.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1113"/>
+        <location filename="mainwindow.cpp" line="1136"/>
         <source>The config was installed successfully.
 
 %1</source>
@@ -528,7 +528,7 @@ Reinstall the GUI to restore the original script, then try again.</source>
 %1</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1118"/>
+        <location filename="mainwindow.cpp" line="1141"/>
         <source>Installing the config failed (code %1).
 
 %2</source>
@@ -537,28 +537,28 @@ Reinstall the GUI to restore the original script, then try again.</source>
 %2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1138"/>
-        <location filename="mainwindow.cpp" line="1148"/>
-        <location filename="mainwindow.cpp" line="1155"/>
+        <location filename="mainwindow.cpp" line="1161"/>
+        <location filename="mainwindow.cpp" line="1171"/>
+        <location filename="mainwindow.cpp" line="1178"/>
         <source>Copy PNG</source>
         <translation>کپی PNG</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="935"/>
         <location filename="mainwindow.cpp" line="944"/>
-        <location filename="mainwindow.cpp" line="1139"/>
-        <location filename="mainwindow.cpp" line="1149"/>
-        <location filename="mainwindow.cpp" line="1156"/>
+        <location filename="mainwindow.cpp" line="1162"/>
+        <location filename="mainwindow.cpp" line="1172"/>
+        <location filename="mainwindow.cpp" line="1179"/>
         <source>Could not copy %1 to %2</source>
         <translation>کپی %1 به %2 ممکن نشد</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1181"/>
+        <location filename="mainwindow.cpp" line="1204"/>
         <source>Invalid PNG</source>
         <translation>PNG نامعتبر</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1182"/>
+        <location filename="mainwindow.cpp" line="1205"/>
         <source>%1 is not a valid PNG file.
 
 Backgrounds and OS icons must be real PNG images (not just files with a .png extension).</source>
@@ -567,58 +567,58 @@ Backgrounds and OS icons must be real PNG images (not just files with a .png ext
 پس‌زمینه‌ها و آیکون‌های سیستم‌عامل باید تصاویر PNG واقعی باشند (نه فقط فایل‌هایی با پسوند ‎.png).</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1445"/>
+        <location filename="mainwindow.cpp" line="1468"/>
         <source>Check For Update</source>
         <translation>بررسی به‌روزرسانی</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1448"/>
+        <location filename="mainwindow.cpp" line="1471"/>
         <source>&lt;p align=&apos;center&apos;&gt;&lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd&apos;&gt;rEFInd Customization GUI v%1&lt;/a&gt;&lt;br&gt;&lt;br&gt;Original GUI Creator: &lt;a href=&apos;https://github.com/jlobue10&apos;&gt;jlobue10&lt;/a&gt;&lt;br&gt;&lt;br&gt;Special Thanks to Deck Wizard for testing and QA&lt;br&gt;&lt;br&gt;&lt;a href=&apos;https://www.youtube.com/watch?v=yBHzVSDVEqw&apos;&gt;Deck Wizard Dual Boot Tutorial&lt;/a&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;&lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd&apos;&gt;rEFInd Customization GUI v%1&lt;/a&gt;&lt;br&gt;&lt;br&gt;سازندهٔ اصلی رابط کاربری: &lt;a href=&apos;https://github.com/jlobue10&apos;&gt;jlobue10&lt;/a&gt;&lt;br&gt;&lt;br&gt;با سپاس ویژه از Deck Wizard برای آزمایش و تضمین کیفیت&lt;br&gt;&lt;br&gt;&lt;a href=&apos;https://www.youtube.com/watch?v=yBHzVSDVEqw&apos;&gt;آموزش دوگانه‌بوت Deck Wizard&lt;/a&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1497"/>
+        <location filename="mainwindow.cpp" line="1520"/>
         <source>&lt;p align=&apos;center&apos;&gt;Update check failed. Please check your internet connection and try again.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;بررسی به‌روزرسانی ناموفق بود. لطفاً اتصال اینترنت خود را بررسی کنید و دوباره تلاش کنید.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1500"/>
+        <location filename="mainwindow.cpp" line="1523"/>
         <source>&lt;p align=&apos;center&apos;&gt;An update is available &lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd/releases&apos;&gt;here&lt;/a&gt;&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;به‌روزرسانی &lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd/releases&apos;&gt;اینجا&lt;/a&gt; در دسترس است&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1504"/>
+        <location filename="mainwindow.cpp" line="1527"/>
         <source>&lt;p align=&apos;center&apos;&gt;No update found. You are using the latest version.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;به‌روزرسانی‌ای پیدا نشد. شما از آخرین نسخه استفاده می‌کنید.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1514"/>
-        <location filename="mainwindow.cpp" line="1521"/>
+        <location filename="mainwindow.cpp" line="1537"/>
+        <location filename="mainwindow.cpp" line="1544"/>
         <source>systemd service</source>
         <translation>سرویس systemd</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1515"/>
-        <location filename="mainwindow.cpp" line="1522"/>
+        <location filename="mainwindow.cpp" line="1538"/>
+        <location filename="mainwindow.cpp" line="1545"/>
         <source>Failed to launch the service toggle.</source>
         <translation>اجرای تغییر وضعیت سرویس ممکن نشد.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1528"/>
-        <location filename="mainwindow.cpp" line="1535"/>
+        <location filename="mainwindow.cpp" line="1551"/>
+        <location filename="mainwindow.cpp" line="1558"/>
         <source>Background Randomizer</source>
         <translation>پس‌زمینهٔ تصادفی</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1529"/>
-        <location filename="mainwindow.cpp" line="1536"/>
-        <location filename="mainwindow.cpp" line="1577"/>
-        <location filename="mainwindow.cpp" line="1584"/>
+        <location filename="mainwindow.cpp" line="1552"/>
+        <location filename="mainwindow.cpp" line="1559"/>
+        <location filename="mainwindow.cpp" line="1600"/>
+        <location filename="mainwindow.cpp" line="1607"/>
         <source>Failed to launch the randomizer setup.</source>
         <translation>اجرای تنظیم پس‌زمینهٔ تصادفی ممکن نشد.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1546"/>
+        <location filename="mainwindow.cpp" line="1569"/>
         <source>The themes-install script was NOT run:
 
 %1
@@ -635,12 +635,12 @@ Reinstall the GUI (on SteamOS, re-run install-GUI.sh) to install or restore it, 
 برای نصب یا بازگرداندن آن، رابط کاربری را دوباره نصب کنید (در SteamOS دوباره install-GUI.sh را اجرا کنید) و بعد دوباره تلاش کنید.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1562"/>
+        <location filename="mainwindow.cpp" line="1585"/>
         <source>The themes were installed successfully.</source>
         <translation>تم‌ها با موفقیت نصب شدند.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1563"/>
+        <location filename="mainwindow.cpp" line="1586"/>
         <source>The themes were installed successfully.
 
 %1</source>
@@ -649,12 +649,12 @@ Reinstall the GUI (on SteamOS, re-run install-GUI.sh) to install or restore it, 
 %1</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1567"/>
+        <location filename="mainwindow.cpp" line="1590"/>
         <source>Installing the themes failed (code %1).</source>
         <translation>نصب تم‌ها ناموفق بود (کد %1).</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1568"/>
+        <location filename="mainwindow.cpp" line="1591"/>
         <source>Installing the themes failed (code %1).
 
 %2</source>
@@ -663,13 +663,13 @@ Reinstall the GUI (on SteamOS, re-run install-GUI.sh) to install or restore it, 
 %2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1576"/>
-        <location filename="mainwindow.cpp" line="1583"/>
+        <location filename="mainwindow.cpp" line="1599"/>
+        <location filename="mainwindow.cpp" line="1606"/>
         <source>Theme Randomizer</source>
         <translation>تم تصادفی</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1591"/>
+        <location filename="mainwindow.cpp" line="1614"/>
         <source>Failed to open %1 in the file manager.</source>
         <translation>باز کردن %1 در مدیر فایل ممکن نشد.</translation>
     </message>
@@ -696,22 +696,32 @@ Reinstall the GUI (on SteamOS, re-run install-GUI.sh) to install or restore it, 
 <context>
     <name>PreviewDialog</name>
     <message>
-        <location filename="previewdialog.cpp" line="34"/>
+        <location filename="previewdialog.cpp" line="62"/>
         <source>No boot options selected.</source>
         <translation>هیچ گزینهٔ بوتی انتخاب نشده است.</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="89"/>
+        <location filename="previewdialog.cpp" line="166"/>
         <source>Preview</source>
         <translation>پیش‌نمایش</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="101"/>
+        <location filename="previewdialog.cpp" line="181"/>
         <source>Approximate preview — rEFInd&apos;s real rendering also depends on the firmware resolution and theme.</source>
         <translation>پیش‌نمایش تقریبی — نمایش واقعی rEFInd به وضوح میان‌افزار و پوسته هم بستگی دارد.</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="107"/>
+        <location filename="previewdialog.cpp" line="184"/>
+        <source>Approximate preview showing the randomly picked &quot;%1&quot; theme — Random picks a theme anew each time the config is created.</source>
+        <translation>پیش‌نمایش تقریبی با پوستهٔ «%1» که به‌صورت تصادفی انتخاب شده — «تصادفی» هر بار که پیکربندی ساخته می‌شود پوسته‌ای تازه انتخاب می‌کند.</translation>
+    </message>
+    <message>
+        <location filename="previewdialog.cpp" line="188"/>
+        <source>Approximate preview with the &quot;%1&quot; theme applied — rEFInd&apos;s real rendering also depends on the firmware resolution and the theme&apos;s other settings.</source>
+        <translation>پیش‌نمایش تقریبی با اعمال پوستهٔ «%1» — نمایش واقعی rEFInd به وضوح میان‌افزار و دیگر تنظیمات پوسته هم بستگی دارد.</translation>
+    </message>
+    <message>
+        <location filename="previewdialog.cpp" line="197"/>
         <source>Boot screen</source>
         <translation>صفحهٔ بوت</translation>
     </message>

--- a/GUI/src/SteamDeck_rEFInd_fr.ts
+++ b/GUI/src/SteamDeck_rEFInd_fr.ts
@@ -120,7 +120,7 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="468"/>
-        <location filename="mainwindow.cpp" line="1590"/>
+        <location filename="mainwindow.cpp" line="1613"/>
         <source>Open Folder</source>
         <translation>Ouvrir le dossier</translation>
     </message>
@@ -280,9 +280,9 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="965"/>
-        <location filename="mainwindow.cpp" line="1545"/>
-        <location filename="mainwindow.cpp" line="1560"/>
-        <location filename="mainwindow.cpp" line="1565"/>
+        <location filename="mainwindow.cpp" line="1568"/>
+        <location filename="mainwindow.cpp" line="1583"/>
+        <location filename="mainwindow.cpp" line="1588"/>
         <source>Install Themes</source>
         <translation>Installer thèmes</translation>
     </message>
@@ -325,10 +325,10 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="1080"/>
-        <location filename="mainwindow.cpp" line="1086"/>
-        <location filename="mainwindow.cpp" line="1104"/>
-        <location filename="mainwindow.cpp" line="1110"/>
-        <location filename="mainwindow.cpp" line="1115"/>
+        <location filename="mainwindow.cpp" line="1109"/>
+        <location filename="mainwindow.cpp" line="1127"/>
+        <location filename="mainwindow.cpp" line="1133"/>
+        <location filename="mainwindow.cpp" line="1138"/>
         <source>Install Config</source>
         <translation>Installer config</translation>
     </message>
@@ -491,7 +491,7 @@
         <translation>Impossible d&apos;écrire %1 entièrement — le disque est peut-être plein. La configuration n&apos;a pas été mise à jour.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1087"/>
+        <location filename="mainwindow.cpp" line="1110"/>
         <source>The config-install script was NOT run:
 
 %1
@@ -508,18 +508,18 @@ Il ne correspond pas à la copie livrée avec cette version de l&apos;applicatio
 Réinstallez la GUI pour restaurer le script d&apos;origine, puis réessayez.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1105"/>
-        <location filename="mainwindow.cpp" line="1117"/>
+        <location filename="mainwindow.cpp" line="1128"/>
+        <location filename="mainwindow.cpp" line="1140"/>
         <source>Installing the config failed (code %1).</source>
         <translation>L&apos;installation de la configuration a échoué (code %1).</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1112"/>
+        <location filename="mainwindow.cpp" line="1135"/>
         <source>The config was installed successfully.</source>
         <translation>La configuration a été installée avec succès.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1113"/>
+        <location filename="mainwindow.cpp" line="1136"/>
         <source>The config was installed successfully.
 
 %1</source>
@@ -528,7 +528,7 @@ Réinstallez la GUI pour restaurer le script d&apos;origine, puis réessayez.</t
 %1</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1118"/>
+        <location filename="mainwindow.cpp" line="1141"/>
         <source>Installing the config failed (code %1).
 
 %2</source>
@@ -537,28 +537,28 @@ Réinstallez la GUI pour restaurer le script d&apos;origine, puis réessayez.</t
 %2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1138"/>
-        <location filename="mainwindow.cpp" line="1148"/>
-        <location filename="mainwindow.cpp" line="1155"/>
+        <location filename="mainwindow.cpp" line="1161"/>
+        <location filename="mainwindow.cpp" line="1171"/>
+        <location filename="mainwindow.cpp" line="1178"/>
         <source>Copy PNG</source>
         <translation>Copier le PNG</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="935"/>
         <location filename="mainwindow.cpp" line="944"/>
-        <location filename="mainwindow.cpp" line="1139"/>
-        <location filename="mainwindow.cpp" line="1149"/>
-        <location filename="mainwindow.cpp" line="1156"/>
+        <location filename="mainwindow.cpp" line="1162"/>
+        <location filename="mainwindow.cpp" line="1172"/>
+        <location filename="mainwindow.cpp" line="1179"/>
         <source>Could not copy %1 to %2</source>
         <translation>Impossible de copier %1 vers %2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1181"/>
+        <location filename="mainwindow.cpp" line="1204"/>
         <source>Invalid PNG</source>
         <translation>PNG non valide</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1182"/>
+        <location filename="mainwindow.cpp" line="1205"/>
         <source>%1 is not a valid PNG file.
 
 Backgrounds and OS icons must be real PNG images (not just files with a .png extension).</source>
@@ -567,58 +567,58 @@ Backgrounds and OS icons must be real PNG images (not just files with a .png ext
 Les arrière-plans et les icônes d&apos;OS doivent être de véritables images PNG (pas seulement des fichiers portant l&apos;extension .png).</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1445"/>
+        <location filename="mainwindow.cpp" line="1468"/>
         <source>Check For Update</source>
         <translation>Vérifier les mises à jour</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1448"/>
+        <location filename="mainwindow.cpp" line="1471"/>
         <source>&lt;p align=&apos;center&apos;&gt;&lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd&apos;&gt;rEFInd Customization GUI v%1&lt;/a&gt;&lt;br&gt;&lt;br&gt;Original GUI Creator: &lt;a href=&apos;https://github.com/jlobue10&apos;&gt;jlobue10&lt;/a&gt;&lt;br&gt;&lt;br&gt;Special Thanks to Deck Wizard for testing and QA&lt;br&gt;&lt;br&gt;&lt;a href=&apos;https://www.youtube.com/watch?v=yBHzVSDVEqw&apos;&gt;Deck Wizard Dual Boot Tutorial&lt;/a&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;&lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd&apos;&gt;rEFInd Customization GUI v%1&lt;/a&gt;&lt;br&gt;&lt;br&gt;Créateur original de la GUI : &lt;a href=&apos;https://github.com/jlobue10&apos;&gt;jlobue10&lt;/a&gt;&lt;br&gt;&lt;br&gt;Remerciements particuliers à Deck Wizard pour les tests et l&apos;assurance qualité&lt;br&gt;&lt;br&gt;&lt;a href=&apos;https://www.youtube.com/watch?v=yBHzVSDVEqw&apos;&gt;Tutoriel dual boot de Deck Wizard&lt;/a&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1497"/>
+        <location filename="mainwindow.cpp" line="1520"/>
         <source>&lt;p align=&apos;center&apos;&gt;Update check failed. Please check your internet connection and try again.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;La vérification des mises à jour a échoué. Vérifiez votre connexion Internet et réessayez.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1500"/>
+        <location filename="mainwindow.cpp" line="1523"/>
         <source>&lt;p align=&apos;center&apos;&gt;An update is available &lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd/releases&apos;&gt;here&lt;/a&gt;&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;Une mise à jour est disponible &lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd/releases&apos;&gt;ici&lt;/a&gt;&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1504"/>
+        <location filename="mainwindow.cpp" line="1527"/>
         <source>&lt;p align=&apos;center&apos;&gt;No update found. You are using the latest version.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;Aucune mise à jour trouvée. Vous utilisez la dernière version.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1514"/>
-        <location filename="mainwindow.cpp" line="1521"/>
+        <location filename="mainwindow.cpp" line="1537"/>
+        <location filename="mainwindow.cpp" line="1544"/>
         <source>systemd service</source>
         <translation>Service systemd</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1515"/>
-        <location filename="mainwindow.cpp" line="1522"/>
+        <location filename="mainwindow.cpp" line="1538"/>
+        <location filename="mainwindow.cpp" line="1545"/>
         <source>Failed to launch the service toggle.</source>
         <translation>Impossible de lancer le basculement du service.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1528"/>
-        <location filename="mainwindow.cpp" line="1535"/>
+        <location filename="mainwindow.cpp" line="1551"/>
+        <location filename="mainwindow.cpp" line="1558"/>
         <source>Background Randomizer</source>
         <translation>Arrière-plan aléatoire</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1529"/>
-        <location filename="mainwindow.cpp" line="1536"/>
-        <location filename="mainwindow.cpp" line="1577"/>
-        <location filename="mainwindow.cpp" line="1584"/>
+        <location filename="mainwindow.cpp" line="1552"/>
+        <location filename="mainwindow.cpp" line="1559"/>
+        <location filename="mainwindow.cpp" line="1600"/>
+        <location filename="mainwindow.cpp" line="1607"/>
         <source>Failed to launch the randomizer setup.</source>
         <translation>Impossible de lancer la configuration de l&apos;arrière-plan aléatoire.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1546"/>
+        <location filename="mainwindow.cpp" line="1569"/>
         <source>The themes-install script was NOT run:
 
 %1
@@ -635,12 +635,12 @@ Il est manquant, ou il ne correspond pas à la copie livrée avec cette version 
 Réinstallez la GUI (sur SteamOS, relancez install-GUI.sh) pour l&apos;installer ou le restaurer, puis réessayez.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1562"/>
+        <location filename="mainwindow.cpp" line="1585"/>
         <source>The themes were installed successfully.</source>
         <translation>Les thèmes ont été installés avec succès.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1563"/>
+        <location filename="mainwindow.cpp" line="1586"/>
         <source>The themes were installed successfully.
 
 %1</source>
@@ -649,12 +649,12 @@ Réinstallez la GUI (sur SteamOS, relancez install-GUI.sh) pour l&apos;installer
 %1</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1567"/>
+        <location filename="mainwindow.cpp" line="1590"/>
         <source>Installing the themes failed (code %1).</source>
         <translation>L&apos;installation des thèmes a échoué (code %1).</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1568"/>
+        <location filename="mainwindow.cpp" line="1591"/>
         <source>Installing the themes failed (code %1).
 
 %2</source>
@@ -663,13 +663,13 @@ Réinstallez la GUI (sur SteamOS, relancez install-GUI.sh) pour l&apos;installer
 %2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1576"/>
-        <location filename="mainwindow.cpp" line="1583"/>
+        <location filename="mainwindow.cpp" line="1599"/>
+        <location filename="mainwindow.cpp" line="1606"/>
         <source>Theme Randomizer</source>
         <translation>Thème aléatoire</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1591"/>
+        <location filename="mainwindow.cpp" line="1614"/>
         <source>Failed to open %1 in the file manager.</source>
         <translation>Impossible d&apos;ouvrir %1 dans le gestionnaire de fichiers.</translation>
     </message>
@@ -696,22 +696,32 @@ Réinstallez la GUI (sur SteamOS, relancez install-GUI.sh) pour l&apos;installer
 <context>
     <name>PreviewDialog</name>
     <message>
-        <location filename="previewdialog.cpp" line="34"/>
+        <location filename="previewdialog.cpp" line="62"/>
         <source>No boot options selected.</source>
         <translation>Aucune option de démarrage sélectionnée.</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="89"/>
+        <location filename="previewdialog.cpp" line="166"/>
         <source>Preview</source>
         <translation>Aperçu</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="101"/>
+        <location filename="previewdialog.cpp" line="181"/>
         <source>Approximate preview — rEFInd&apos;s real rendering also depends on the firmware resolution and theme.</source>
         <translation>Aperçu approximatif — le rendu réel de rEFInd dépend aussi de la résolution du micrologiciel et du thème.</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="107"/>
+        <location filename="previewdialog.cpp" line="184"/>
+        <source>Approximate preview showing the randomly picked &quot;%1&quot; theme — Random picks a theme anew each time the config is created.</source>
+        <translation>Aperçu approximatif montrant le thème « %1 » choisi au hasard — « Aléatoire » choisit un nouveau thème à chaque création de la configuration.</translation>
+    </message>
+    <message>
+        <location filename="previewdialog.cpp" line="188"/>
+        <source>Approximate preview with the &quot;%1&quot; theme applied — rEFInd&apos;s real rendering also depends on the firmware resolution and the theme&apos;s other settings.</source>
+        <translation>Aperçu approximatif avec le thème « %1 » appliqué — le rendu réel de rEFInd dépend aussi de la résolution du micrologiciel et des autres réglages du thème.</translation>
+    </message>
+    <message>
+        <location filename="previewdialog.cpp" line="197"/>
         <source>Boot screen</source>
         <translation>Écran de démarrage</translation>
     </message>

--- a/GUI/src/SteamDeck_rEFInd_hi.ts
+++ b/GUI/src/SteamDeck_rEFInd_hi.ts
@@ -120,7 +120,7 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="468"/>
-        <location filename="mainwindow.cpp" line="1590"/>
+        <location filename="mainwindow.cpp" line="1613"/>
         <source>Open Folder</source>
         <translation>फ़ोल्डर खोलें</translation>
     </message>
@@ -280,9 +280,9 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="965"/>
-        <location filename="mainwindow.cpp" line="1545"/>
-        <location filename="mainwindow.cpp" line="1560"/>
-        <location filename="mainwindow.cpp" line="1565"/>
+        <location filename="mainwindow.cpp" line="1568"/>
+        <location filename="mainwindow.cpp" line="1583"/>
+        <location filename="mainwindow.cpp" line="1588"/>
         <source>Install Themes</source>
         <translation>थीम इंस्टॉल करें</translation>
     </message>
@@ -325,10 +325,10 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="1080"/>
-        <location filename="mainwindow.cpp" line="1086"/>
-        <location filename="mainwindow.cpp" line="1104"/>
-        <location filename="mainwindow.cpp" line="1110"/>
-        <location filename="mainwindow.cpp" line="1115"/>
+        <location filename="mainwindow.cpp" line="1109"/>
+        <location filename="mainwindow.cpp" line="1127"/>
+        <location filename="mainwindow.cpp" line="1133"/>
+        <location filename="mainwindow.cpp" line="1138"/>
         <source>Install Config</source>
         <translation>कॉन्फ़िग इंस्टॉल करें</translation>
     </message>
@@ -491,7 +491,7 @@
         <translation>%1 पूरी तरह नहीं लिखा जा सका — डिस्क भरी हो सकती है। कॉन्फ़िगरेशन अपडेट नहीं हुआ।</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1087"/>
+        <location filename="mainwindow.cpp" line="1110"/>
         <source>The config-install script was NOT run:
 
 %1
@@ -508,18 +508,18 @@ Reinstall the GUI to restore the original script, then try again.</source>
 मूल स्क्रिप्ट बहाल करने के लिए GUI फिर से इंस्टॉल करें, फिर पुनः प्रयास करें।</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1105"/>
-        <location filename="mainwindow.cpp" line="1117"/>
+        <location filename="mainwindow.cpp" line="1128"/>
+        <location filename="mainwindow.cpp" line="1140"/>
         <source>Installing the config failed (code %1).</source>
         <translation>कॉन्फ़िगरेशन इंस्टॉल विफल रहा (कोड %1)।</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1112"/>
+        <location filename="mainwindow.cpp" line="1135"/>
         <source>The config was installed successfully.</source>
         <translation>कॉन्फ़िगरेशन सफलतापूर्वक इंस्टॉल हो गया।</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1113"/>
+        <location filename="mainwindow.cpp" line="1136"/>
         <source>The config was installed successfully.
 
 %1</source>
@@ -528,7 +528,7 @@ Reinstall the GUI to restore the original script, then try again.</source>
 %1</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1118"/>
+        <location filename="mainwindow.cpp" line="1141"/>
         <source>Installing the config failed (code %1).
 
 %2</source>
@@ -537,28 +537,28 @@ Reinstall the GUI to restore the original script, then try again.</source>
 %2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1138"/>
-        <location filename="mainwindow.cpp" line="1148"/>
-        <location filename="mainwindow.cpp" line="1155"/>
+        <location filename="mainwindow.cpp" line="1161"/>
+        <location filename="mainwindow.cpp" line="1171"/>
+        <location filename="mainwindow.cpp" line="1178"/>
         <source>Copy PNG</source>
         <translation>PNG कॉपी करें</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="935"/>
         <location filename="mainwindow.cpp" line="944"/>
-        <location filename="mainwindow.cpp" line="1139"/>
-        <location filename="mainwindow.cpp" line="1149"/>
-        <location filename="mainwindow.cpp" line="1156"/>
+        <location filename="mainwindow.cpp" line="1162"/>
+        <location filename="mainwindow.cpp" line="1172"/>
+        <location filename="mainwindow.cpp" line="1179"/>
         <source>Could not copy %1 to %2</source>
         <translation>%1 को %2 में कॉपी नहीं किया जा सका</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1181"/>
+        <location filename="mainwindow.cpp" line="1204"/>
         <source>Invalid PNG</source>
         <translation>अमान्य PNG</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1182"/>
+        <location filename="mainwindow.cpp" line="1205"/>
         <source>%1 is not a valid PNG file.
 
 Backgrounds and OS icons must be real PNG images (not just files with a .png extension).</source>
@@ -567,58 +567,58 @@ Backgrounds and OS icons must be real PNG images (not just files with a .png ext
 पृष्ठभूमि और OS आइकन असली PNG छवियाँ होनी चाहिए (केवल .png एक्सटेंशन वाली फ़ाइलें नहीं)।</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1445"/>
+        <location filename="mainwindow.cpp" line="1468"/>
         <source>Check For Update</source>
         <translation>अपडेट जाँचें</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1448"/>
+        <location filename="mainwindow.cpp" line="1471"/>
         <source>&lt;p align=&apos;center&apos;&gt;&lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd&apos;&gt;rEFInd Customization GUI v%1&lt;/a&gt;&lt;br&gt;&lt;br&gt;Original GUI Creator: &lt;a href=&apos;https://github.com/jlobue10&apos;&gt;jlobue10&lt;/a&gt;&lt;br&gt;&lt;br&gt;Special Thanks to Deck Wizard for testing and QA&lt;br&gt;&lt;br&gt;&lt;a href=&apos;https://www.youtube.com/watch?v=yBHzVSDVEqw&apos;&gt;Deck Wizard Dual Boot Tutorial&lt;/a&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;&lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd&apos;&gt;rEFInd Customization GUI v%1&lt;/a&gt;&lt;br&gt;&lt;br&gt;मूल GUI निर्माता: &lt;a href=&apos;https://github.com/jlobue10&apos;&gt;jlobue10&lt;/a&gt;&lt;br&gt;&lt;br&gt;परीक्षण और गुणवत्ता जाँच के लिए Deck Wizard का विशेष धन्यवाद&lt;br&gt;&lt;br&gt;&lt;a href=&apos;https://www.youtube.com/watch?v=yBHzVSDVEqw&apos;&gt;Deck Wizard डुअल बूट ट्यूटोरियल&lt;/a&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1497"/>
+        <location filename="mainwindow.cpp" line="1520"/>
         <source>&lt;p align=&apos;center&apos;&gt;Update check failed. Please check your internet connection and try again.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;अपडेट जाँच विफल रही। कृपया अपना इंटरनेट कनेक्शन जाँचें और फिर से प्रयास करें।&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1500"/>
+        <location filename="mainwindow.cpp" line="1523"/>
         <source>&lt;p align=&apos;center&apos;&gt;An update is available &lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd/releases&apos;&gt;here&lt;/a&gt;&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;अपडेट &lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd/releases&apos;&gt;यहाँ&lt;/a&gt; उपलब्ध है&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1504"/>
+        <location filename="mainwindow.cpp" line="1527"/>
         <source>&lt;p align=&apos;center&apos;&gt;No update found. You are using the latest version.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;कोई अपडेट नहीं मिला। आप नवीनतम संस्करण उपयोग कर रहे हैं।&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1514"/>
-        <location filename="mainwindow.cpp" line="1521"/>
+        <location filename="mainwindow.cpp" line="1537"/>
+        <location filename="mainwindow.cpp" line="1544"/>
         <source>systemd service</source>
         <translation>systemd सेवा</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1515"/>
-        <location filename="mainwindow.cpp" line="1522"/>
+        <location filename="mainwindow.cpp" line="1538"/>
+        <location filename="mainwindow.cpp" line="1545"/>
         <source>Failed to launch the service toggle.</source>
         <translation>सेवा टॉगल शुरू नहीं हो सका।</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1528"/>
-        <location filename="mainwindow.cpp" line="1535"/>
+        <location filename="mainwindow.cpp" line="1551"/>
+        <location filename="mainwindow.cpp" line="1558"/>
         <source>Background Randomizer</source>
         <translation>यादृच्छिक पृष्ठभूमि</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1529"/>
-        <location filename="mainwindow.cpp" line="1536"/>
-        <location filename="mainwindow.cpp" line="1577"/>
-        <location filename="mainwindow.cpp" line="1584"/>
+        <location filename="mainwindow.cpp" line="1552"/>
+        <location filename="mainwindow.cpp" line="1559"/>
+        <location filename="mainwindow.cpp" line="1600"/>
+        <location filename="mainwindow.cpp" line="1607"/>
         <source>Failed to launch the randomizer setup.</source>
         <translation>यादृच्छिक पृष्ठभूमि सेटअप शुरू नहीं हो सका।</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1546"/>
+        <location filename="mainwindow.cpp" line="1569"/>
         <source>The themes-install script was NOT run:
 
 %1
@@ -635,12 +635,12 @@ Reinstall the GUI (on SteamOS, re-run install-GUI.sh) to install or restore it, 
 इसे इंस्टॉल या बहाल करने के लिए GUI फिर से इंस्टॉल करें (SteamOS पर install-GUI.sh दोबारा चलाएँ), फिर पुनः प्रयास करें।</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1562"/>
+        <location filename="mainwindow.cpp" line="1585"/>
         <source>The themes were installed successfully.</source>
         <translation>थीमें सफलतापूर्वक इंस्टॉल हो गईं।</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1563"/>
+        <location filename="mainwindow.cpp" line="1586"/>
         <source>The themes were installed successfully.
 
 %1</source>
@@ -649,12 +649,12 @@ Reinstall the GUI (on SteamOS, re-run install-GUI.sh) to install or restore it, 
 %1</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1567"/>
+        <location filename="mainwindow.cpp" line="1590"/>
         <source>Installing the themes failed (code %1).</source>
         <translation>थीम इंस्टॉल विफल रहा (कोड %1)।</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1568"/>
+        <location filename="mainwindow.cpp" line="1591"/>
         <source>Installing the themes failed (code %1).
 
 %2</source>
@@ -663,13 +663,13 @@ Reinstall the GUI (on SteamOS, re-run install-GUI.sh) to install or restore it, 
 %2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1576"/>
-        <location filename="mainwindow.cpp" line="1583"/>
+        <location filename="mainwindow.cpp" line="1599"/>
+        <location filename="mainwindow.cpp" line="1606"/>
         <source>Theme Randomizer</source>
         <translation>यादृच्छिक थीम</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1591"/>
+        <location filename="mainwindow.cpp" line="1614"/>
         <source>Failed to open %1 in the file manager.</source>
         <translation>फ़ाइल प्रबंधक में %1 खोला नहीं जा सका।</translation>
     </message>
@@ -696,22 +696,32 @@ Reinstall the GUI (on SteamOS, re-run install-GUI.sh) to install or restore it, 
 <context>
     <name>PreviewDialog</name>
     <message>
-        <location filename="previewdialog.cpp" line="34"/>
+        <location filename="previewdialog.cpp" line="62"/>
         <source>No boot options selected.</source>
         <translation>कोई बूट विकल्प चयनित नहीं है।</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="89"/>
+        <location filename="previewdialog.cpp" line="166"/>
         <source>Preview</source>
         <translation>पूर्वावलोकन</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="101"/>
+        <location filename="previewdialog.cpp" line="181"/>
         <source>Approximate preview — rEFInd&apos;s real rendering also depends on the firmware resolution and theme.</source>
         <translation>अनुमानित पूर्वावलोकन — rEFInd का वास्तविक प्रदर्शन फ़र्मवेयर रिज़ॉल्यूशन और थीम पर भी निर्भर करता है।</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="107"/>
+        <location filename="previewdialog.cpp" line="184"/>
+        <source>Approximate preview showing the randomly picked &quot;%1&quot; theme — Random picks a theme anew each time the config is created.</source>
+        <translation>यादृच्छिक रूप से चुनी गई थीम &quot;%1&quot; दिखाता अनुमानित पूर्वावलोकन — &quot;यादृच्छिक&quot; हर बार कॉन्फ़िग बनाते समय नई थीम चुनता है।</translation>
+    </message>
+    <message>
+        <location filename="previewdialog.cpp" line="188"/>
+        <source>Approximate preview with the &quot;%1&quot; theme applied — rEFInd&apos;s real rendering also depends on the firmware resolution and the theme&apos;s other settings.</source>
+        <translation>थीम &quot;%1&quot; लागू किए हुए अनुमानित पूर्वावलोकन — rEFInd का वास्तविक प्रदर्शन फ़र्मवेयर रिज़ॉल्यूशन और थीम की अन्य सेटिंग्स पर भी निर्भर करता है।</translation>
+    </message>
+    <message>
+        <location filename="previewdialog.cpp" line="197"/>
         <source>Boot screen</source>
         <translation>बूट स्क्रीन</translation>
     </message>

--- a/GUI/src/SteamDeck_rEFInd_id.ts
+++ b/GUI/src/SteamDeck_rEFInd_id.ts
@@ -120,7 +120,7 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="468"/>
-        <location filename="mainwindow.cpp" line="1590"/>
+        <location filename="mainwindow.cpp" line="1613"/>
         <source>Open Folder</source>
         <translation>Buka folder</translation>
     </message>
@@ -280,9 +280,9 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="965"/>
-        <location filename="mainwindow.cpp" line="1545"/>
-        <location filename="mainwindow.cpp" line="1560"/>
-        <location filename="mainwindow.cpp" line="1565"/>
+        <location filename="mainwindow.cpp" line="1568"/>
+        <location filename="mainwindow.cpp" line="1583"/>
+        <location filename="mainwindow.cpp" line="1588"/>
         <source>Install Themes</source>
         <translation>Pasang tema</translation>
     </message>
@@ -325,10 +325,10 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="1080"/>
-        <location filename="mainwindow.cpp" line="1086"/>
-        <location filename="mainwindow.cpp" line="1104"/>
-        <location filename="mainwindow.cpp" line="1110"/>
-        <location filename="mainwindow.cpp" line="1115"/>
+        <location filename="mainwindow.cpp" line="1109"/>
+        <location filename="mainwindow.cpp" line="1127"/>
+        <location filename="mainwindow.cpp" line="1133"/>
+        <location filename="mainwindow.cpp" line="1138"/>
         <source>Install Config</source>
         <translation>Pasang konfigurasi</translation>
     </message>
@@ -491,7 +491,7 @@
         <translation>Tidak dapat menulis %1 sepenuhnya — disk mungkin penuh. Konfigurasi tidak diperbarui.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1087"/>
+        <location filename="mainwindow.cpp" line="1110"/>
         <source>The config-install script was NOT run:
 
 %1
@@ -508,18 +508,18 @@ Skrip tidak cocok dengan salinan yang disertakan pada versi aplikasi ini. Karena
 Pasang ulang GUI untuk memulihkan skrip asli, lalu coba lagi.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1105"/>
-        <location filename="mainwindow.cpp" line="1117"/>
+        <location filename="mainwindow.cpp" line="1128"/>
+        <location filename="mainwindow.cpp" line="1140"/>
         <source>Installing the config failed (code %1).</source>
         <translation>Pemasangan konfigurasi gagal (kode %1).</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1112"/>
+        <location filename="mainwindow.cpp" line="1135"/>
         <source>The config was installed successfully.</source>
         <translation>Konfigurasi berhasil dipasang.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1113"/>
+        <location filename="mainwindow.cpp" line="1136"/>
         <source>The config was installed successfully.
 
 %1</source>
@@ -528,7 +528,7 @@ Pasang ulang GUI untuk memulihkan skrip asli, lalu coba lagi.</translation>
 %1</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1118"/>
+        <location filename="mainwindow.cpp" line="1141"/>
         <source>Installing the config failed (code %1).
 
 %2</source>
@@ -537,28 +537,28 @@ Pasang ulang GUI untuk memulihkan skrip asli, lalu coba lagi.</translation>
 %2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1138"/>
-        <location filename="mainwindow.cpp" line="1148"/>
-        <location filename="mainwindow.cpp" line="1155"/>
+        <location filename="mainwindow.cpp" line="1161"/>
+        <location filename="mainwindow.cpp" line="1171"/>
+        <location filename="mainwindow.cpp" line="1178"/>
         <source>Copy PNG</source>
         <translation>Salin PNG</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="935"/>
         <location filename="mainwindow.cpp" line="944"/>
-        <location filename="mainwindow.cpp" line="1139"/>
-        <location filename="mainwindow.cpp" line="1149"/>
-        <location filename="mainwindow.cpp" line="1156"/>
+        <location filename="mainwindow.cpp" line="1162"/>
+        <location filename="mainwindow.cpp" line="1172"/>
+        <location filename="mainwindow.cpp" line="1179"/>
         <source>Could not copy %1 to %2</source>
         <translation>Tidak dapat menyalin %1 ke %2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1181"/>
+        <location filename="mainwindow.cpp" line="1204"/>
         <source>Invalid PNG</source>
         <translation>PNG tidak valid</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1182"/>
+        <location filename="mainwindow.cpp" line="1205"/>
         <source>%1 is not a valid PNG file.
 
 Backgrounds and OS icons must be real PNG images (not just files with a .png extension).</source>
@@ -567,58 +567,58 @@ Backgrounds and OS icons must be real PNG images (not just files with a .png ext
 Latar belakang dan ikon OS harus berupa gambar PNG asli (bukan sekadar berkas berekstensi .png).</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1445"/>
+        <location filename="mainwindow.cpp" line="1468"/>
         <source>Check For Update</source>
         <translation>Periksa pembaruan</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1448"/>
+        <location filename="mainwindow.cpp" line="1471"/>
         <source>&lt;p align=&apos;center&apos;&gt;&lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd&apos;&gt;rEFInd Customization GUI v%1&lt;/a&gt;&lt;br&gt;&lt;br&gt;Original GUI Creator: &lt;a href=&apos;https://github.com/jlobue10&apos;&gt;jlobue10&lt;/a&gt;&lt;br&gt;&lt;br&gt;Special Thanks to Deck Wizard for testing and QA&lt;br&gt;&lt;br&gt;&lt;a href=&apos;https://www.youtube.com/watch?v=yBHzVSDVEqw&apos;&gt;Deck Wizard Dual Boot Tutorial&lt;/a&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;&lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd&apos;&gt;rEFInd Customization GUI v%1&lt;/a&gt;&lt;br&gt;&lt;br&gt;Pembuat GUI asli: &lt;a href=&apos;https://github.com/jlobue10&apos;&gt;jlobue10&lt;/a&gt;&lt;br&gt;&lt;br&gt;Terima kasih khusus kepada Deck Wizard atas pengujian dan penjaminan mutu&lt;br&gt;&lt;br&gt;&lt;a href=&apos;https://www.youtube.com/watch?v=yBHzVSDVEqw&apos;&gt;Tutorial dual boot Deck Wizard&lt;/a&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1497"/>
+        <location filename="mainwindow.cpp" line="1520"/>
         <source>&lt;p align=&apos;center&apos;&gt;Update check failed. Please check your internet connection and try again.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;Pemeriksaan pembaruan gagal. Periksa koneksi internet Anda dan coba lagi.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1500"/>
+        <location filename="mainwindow.cpp" line="1523"/>
         <source>&lt;p align=&apos;center&apos;&gt;An update is available &lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd/releases&apos;&gt;here&lt;/a&gt;&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;Pembaruan tersedia &lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd/releases&apos;&gt;di sini&lt;/a&gt;&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1504"/>
+        <location filename="mainwindow.cpp" line="1527"/>
         <source>&lt;p align=&apos;center&apos;&gt;No update found. You are using the latest version.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;Tidak ada pembaruan. Anda menggunakan versi terbaru.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1514"/>
-        <location filename="mainwindow.cpp" line="1521"/>
+        <location filename="mainwindow.cpp" line="1537"/>
+        <location filename="mainwindow.cpp" line="1544"/>
         <source>systemd service</source>
         <translation>Layanan systemd</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1515"/>
-        <location filename="mainwindow.cpp" line="1522"/>
+        <location filename="mainwindow.cpp" line="1538"/>
+        <location filename="mainwindow.cpp" line="1545"/>
         <source>Failed to launch the service toggle.</source>
         <translation>Gagal menjalankan pengalihan layanan.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1528"/>
-        <location filename="mainwindow.cpp" line="1535"/>
+        <location filename="mainwindow.cpp" line="1551"/>
+        <location filename="mainwindow.cpp" line="1558"/>
         <source>Background Randomizer</source>
         <translation>Latar belakang acak</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1529"/>
-        <location filename="mainwindow.cpp" line="1536"/>
-        <location filename="mainwindow.cpp" line="1577"/>
-        <location filename="mainwindow.cpp" line="1584"/>
+        <location filename="mainwindow.cpp" line="1552"/>
+        <location filename="mainwindow.cpp" line="1559"/>
+        <location filename="mainwindow.cpp" line="1600"/>
+        <location filename="mainwindow.cpp" line="1607"/>
         <source>Failed to launch the randomizer setup.</source>
         <translation>Gagal menjalankan penyiapan latar belakang acak.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1546"/>
+        <location filename="mainwindow.cpp" line="1569"/>
         <source>The themes-install script was NOT run:
 
 %1
@@ -635,12 +635,12 @@ Skrip hilang, atau tidak cocok dengan salinan yang disertakan pada versi aplikas
 Pasang ulang GUI (di SteamOS, jalankan lagi install-GUI.sh) untuk memasang atau memulihkannya, lalu coba lagi.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1562"/>
+        <location filename="mainwindow.cpp" line="1585"/>
         <source>The themes were installed successfully.</source>
         <translation>Tema berhasil dipasang.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1563"/>
+        <location filename="mainwindow.cpp" line="1586"/>
         <source>The themes were installed successfully.
 
 %1</source>
@@ -649,12 +649,12 @@ Pasang ulang GUI (di SteamOS, jalankan lagi install-GUI.sh) untuk memasang atau 
 %1</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1567"/>
+        <location filename="mainwindow.cpp" line="1590"/>
         <source>Installing the themes failed (code %1).</source>
         <translation>Pemasangan tema gagal (kode %1).</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1568"/>
+        <location filename="mainwindow.cpp" line="1591"/>
         <source>Installing the themes failed (code %1).
 
 %2</source>
@@ -663,13 +663,13 @@ Pasang ulang GUI (di SteamOS, jalankan lagi install-GUI.sh) untuk memasang atau 
 %2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1576"/>
-        <location filename="mainwindow.cpp" line="1583"/>
+        <location filename="mainwindow.cpp" line="1599"/>
+        <location filename="mainwindow.cpp" line="1606"/>
         <source>Theme Randomizer</source>
         <translation>Tema acak</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1591"/>
+        <location filename="mainwindow.cpp" line="1614"/>
         <source>Failed to open %1 in the file manager.</source>
         <translation>Gagal membuka %1 di pengelola berkas.</translation>
     </message>
@@ -696,22 +696,32 @@ Pasang ulang GUI (di SteamOS, jalankan lagi install-GUI.sh) untuk memasang atau 
 <context>
     <name>PreviewDialog</name>
     <message>
-        <location filename="previewdialog.cpp" line="34"/>
+        <location filename="previewdialog.cpp" line="62"/>
         <source>No boot options selected.</source>
         <translation>Tidak ada opsi boot yang dipilih.</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="89"/>
+        <location filename="previewdialog.cpp" line="166"/>
         <source>Preview</source>
         <translation>Pratinjau</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="101"/>
+        <location filename="previewdialog.cpp" line="181"/>
         <source>Approximate preview — rEFInd&apos;s real rendering also depends on the firmware resolution and theme.</source>
         <translation>Pratinjau perkiraan — tampilan rEFInd sebenarnya juga bergantung pada resolusi firmware dan tema.</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="107"/>
+        <location filename="previewdialog.cpp" line="184"/>
+        <source>Approximate preview showing the randomly picked &quot;%1&quot; theme — Random picks a theme anew each time the config is created.</source>
+        <translation>Pratinjau perkiraan menampilkan tema &quot;%1&quot; yang dipilih secara acak — &quot;Acak&quot; memilih tema baru setiap kali konfigurasi dibuat.</translation>
+    </message>
+    <message>
+        <location filename="previewdialog.cpp" line="188"/>
+        <source>Approximate preview with the &quot;%1&quot; theme applied — rEFInd&apos;s real rendering also depends on the firmware resolution and the theme&apos;s other settings.</source>
+        <translation>Pratinjau perkiraan dengan tema &quot;%1&quot; diterapkan — tampilan rEFInd sebenarnya juga bergantung pada resolusi firmware dan pengaturan tema lainnya.</translation>
+    </message>
+    <message>
+        <location filename="previewdialog.cpp" line="197"/>
         <source>Boot screen</source>
         <translation>Layar boot</translation>
     </message>

--- a/GUI/src/SteamDeck_rEFInd_it.ts
+++ b/GUI/src/SteamDeck_rEFInd_it.ts
@@ -120,7 +120,7 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="468"/>
-        <location filename="mainwindow.cpp" line="1590"/>
+        <location filename="mainwindow.cpp" line="1613"/>
         <source>Open Folder</source>
         <translation>Apri cartella</translation>
     </message>
@@ -280,9 +280,9 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="965"/>
-        <location filename="mainwindow.cpp" line="1545"/>
-        <location filename="mainwindow.cpp" line="1560"/>
-        <location filename="mainwindow.cpp" line="1565"/>
+        <location filename="mainwindow.cpp" line="1568"/>
+        <location filename="mainwindow.cpp" line="1583"/>
+        <location filename="mainwindow.cpp" line="1588"/>
         <source>Install Themes</source>
         <translation>Installa temi</translation>
     </message>
@@ -325,10 +325,10 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="1080"/>
-        <location filename="mainwindow.cpp" line="1086"/>
-        <location filename="mainwindow.cpp" line="1104"/>
-        <location filename="mainwindow.cpp" line="1110"/>
-        <location filename="mainwindow.cpp" line="1115"/>
+        <location filename="mainwindow.cpp" line="1109"/>
+        <location filename="mainwindow.cpp" line="1127"/>
+        <location filename="mainwindow.cpp" line="1133"/>
+        <location filename="mainwindow.cpp" line="1138"/>
         <source>Install Config</source>
         <translation>Installa config</translation>
     </message>
@@ -491,7 +491,7 @@
         <translation>Impossibile scrivere %1 completamente — il disco potrebbe essere pieno. La configurazione non è stata aggiornata.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1087"/>
+        <location filename="mainwindow.cpp" line="1110"/>
         <source>The config-install script was NOT run:
 
 %1
@@ -508,18 +508,18 @@ Non corrisponde alla copia fornita con questa versione dell&apos;app. Poiché vi
 Reinstalla la GUI per ripristinare lo script originale, poi riprova.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1105"/>
-        <location filename="mainwindow.cpp" line="1117"/>
+        <location filename="mainwindow.cpp" line="1128"/>
+        <location filename="mainwindow.cpp" line="1140"/>
         <source>Installing the config failed (code %1).</source>
         <translation>Installazione della configurazione non riuscita (codice %1).</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1112"/>
+        <location filename="mainwindow.cpp" line="1135"/>
         <source>The config was installed successfully.</source>
         <translation>La configurazione è stata installata correttamente.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1113"/>
+        <location filename="mainwindow.cpp" line="1136"/>
         <source>The config was installed successfully.
 
 %1</source>
@@ -528,7 +528,7 @@ Reinstalla la GUI per ripristinare lo script originale, poi riprova.</translatio
 %1</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1118"/>
+        <location filename="mainwindow.cpp" line="1141"/>
         <source>Installing the config failed (code %1).
 
 %2</source>
@@ -537,28 +537,28 @@ Reinstalla la GUI per ripristinare lo script originale, poi riprova.</translatio
 %2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1138"/>
-        <location filename="mainwindow.cpp" line="1148"/>
-        <location filename="mainwindow.cpp" line="1155"/>
+        <location filename="mainwindow.cpp" line="1161"/>
+        <location filename="mainwindow.cpp" line="1171"/>
+        <location filename="mainwindow.cpp" line="1178"/>
         <source>Copy PNG</source>
         <translation>Copia PNG</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="935"/>
         <location filename="mainwindow.cpp" line="944"/>
-        <location filename="mainwindow.cpp" line="1139"/>
-        <location filename="mainwindow.cpp" line="1149"/>
-        <location filename="mainwindow.cpp" line="1156"/>
+        <location filename="mainwindow.cpp" line="1162"/>
+        <location filename="mainwindow.cpp" line="1172"/>
+        <location filename="mainwindow.cpp" line="1179"/>
         <source>Could not copy %1 to %2</source>
         <translation>Impossibile copiare %1 in %2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1181"/>
+        <location filename="mainwindow.cpp" line="1204"/>
         <source>Invalid PNG</source>
         <translation>PNG non valido</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1182"/>
+        <location filename="mainwindow.cpp" line="1205"/>
         <source>%1 is not a valid PNG file.
 
 Backgrounds and OS icons must be real PNG images (not just files with a .png extension).</source>
@@ -567,58 +567,58 @@ Backgrounds and OS icons must be real PNG images (not just files with a .png ext
 Gli sfondi e le icone di sistema devono essere vere immagini PNG (non semplici file con estensione .png).</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1445"/>
+        <location filename="mainwindow.cpp" line="1468"/>
         <source>Check For Update</source>
         <translation>Controlla aggiornamenti</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1448"/>
+        <location filename="mainwindow.cpp" line="1471"/>
         <source>&lt;p align=&apos;center&apos;&gt;&lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd&apos;&gt;rEFInd Customization GUI v%1&lt;/a&gt;&lt;br&gt;&lt;br&gt;Original GUI Creator: &lt;a href=&apos;https://github.com/jlobue10&apos;&gt;jlobue10&lt;/a&gt;&lt;br&gt;&lt;br&gt;Special Thanks to Deck Wizard for testing and QA&lt;br&gt;&lt;br&gt;&lt;a href=&apos;https://www.youtube.com/watch?v=yBHzVSDVEqw&apos;&gt;Deck Wizard Dual Boot Tutorial&lt;/a&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;&lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd&apos;&gt;rEFInd Customization GUI v%1&lt;/a&gt;&lt;br&gt;&lt;br&gt;Creatore originale della GUI: &lt;a href=&apos;https://github.com/jlobue10&apos;&gt;jlobue10&lt;/a&gt;&lt;br&gt;&lt;br&gt;Un ringraziamento speciale a Deck Wizard per i test e il controllo qualità&lt;br&gt;&lt;br&gt;&lt;a href=&apos;https://www.youtube.com/watch?v=yBHzVSDVEqw&apos;&gt;Tutorial dual boot di Deck Wizard&lt;/a&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1497"/>
+        <location filename="mainwindow.cpp" line="1520"/>
         <source>&lt;p align=&apos;center&apos;&gt;Update check failed. Please check your internet connection and try again.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;Controllo aggiornamenti non riuscito. Verifica la connessione a Internet e riprova.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1500"/>
+        <location filename="mainwindow.cpp" line="1523"/>
         <source>&lt;p align=&apos;center&apos;&gt;An update is available &lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd/releases&apos;&gt;here&lt;/a&gt;&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;È disponibile un aggiornamento &lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd/releases&apos;&gt;qui&lt;/a&gt;&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1504"/>
+        <location filename="mainwindow.cpp" line="1527"/>
         <source>&lt;p align=&apos;center&apos;&gt;No update found. You are using the latest version.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;Nessun aggiornamento trovato. Stai usando la versione più recente.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1514"/>
-        <location filename="mainwindow.cpp" line="1521"/>
+        <location filename="mainwindow.cpp" line="1537"/>
+        <location filename="mainwindow.cpp" line="1544"/>
         <source>systemd service</source>
         <translation>Servizio systemd</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1515"/>
-        <location filename="mainwindow.cpp" line="1522"/>
+        <location filename="mainwindow.cpp" line="1538"/>
+        <location filename="mainwindow.cpp" line="1545"/>
         <source>Failed to launch the service toggle.</source>
         <translation>Impossibile avviare la commutazione del servizio.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1528"/>
-        <location filename="mainwindow.cpp" line="1535"/>
+        <location filename="mainwindow.cpp" line="1551"/>
+        <location filename="mainwindow.cpp" line="1558"/>
         <source>Background Randomizer</source>
         <translation>Sfondo casuale</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1529"/>
-        <location filename="mainwindow.cpp" line="1536"/>
-        <location filename="mainwindow.cpp" line="1577"/>
-        <location filename="mainwindow.cpp" line="1584"/>
+        <location filename="mainwindow.cpp" line="1552"/>
+        <location filename="mainwindow.cpp" line="1559"/>
+        <location filename="mainwindow.cpp" line="1600"/>
+        <location filename="mainwindow.cpp" line="1607"/>
         <source>Failed to launch the randomizer setup.</source>
         <translation>Impossibile avviare la configurazione dello sfondo casuale.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1546"/>
+        <location filename="mainwindow.cpp" line="1569"/>
         <source>The themes-install script was NOT run:
 
 %1
@@ -635,12 +635,12 @@ Manca, oppure non corrisponde alla copia fornita con questa versione dell&apos;a
 Reinstalla la GUI (su SteamOS, riesegui install-GUI.sh) per installarlo o ripristinarlo, poi riprova.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1562"/>
+        <location filename="mainwindow.cpp" line="1585"/>
         <source>The themes were installed successfully.</source>
         <translation>I temi sono stati installati correttamente.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1563"/>
+        <location filename="mainwindow.cpp" line="1586"/>
         <source>The themes were installed successfully.
 
 %1</source>
@@ -649,12 +649,12 @@ Reinstalla la GUI (su SteamOS, riesegui install-GUI.sh) per installarlo o ripris
 %1</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1567"/>
+        <location filename="mainwindow.cpp" line="1590"/>
         <source>Installing the themes failed (code %1).</source>
         <translation>Installazione dei temi non riuscita (codice %1).</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1568"/>
+        <location filename="mainwindow.cpp" line="1591"/>
         <source>Installing the themes failed (code %1).
 
 %2</source>
@@ -663,13 +663,13 @@ Reinstalla la GUI (su SteamOS, riesegui install-GUI.sh) per installarlo o ripris
 %2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1576"/>
-        <location filename="mainwindow.cpp" line="1583"/>
+        <location filename="mainwindow.cpp" line="1599"/>
+        <location filename="mainwindow.cpp" line="1606"/>
         <source>Theme Randomizer</source>
         <translation>Tema casuale</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1591"/>
+        <location filename="mainwindow.cpp" line="1614"/>
         <source>Failed to open %1 in the file manager.</source>
         <translation>Impossibile aprire %1 nel gestore file.</translation>
     </message>
@@ -696,22 +696,32 @@ Reinstalla la GUI (su SteamOS, riesegui install-GUI.sh) per installarlo o ripris
 <context>
     <name>PreviewDialog</name>
     <message>
-        <location filename="previewdialog.cpp" line="34"/>
+        <location filename="previewdialog.cpp" line="62"/>
         <source>No boot options selected.</source>
         <translation>Nessuna opzione di avvio selezionata.</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="89"/>
+        <location filename="previewdialog.cpp" line="166"/>
         <source>Preview</source>
         <translation>Anteprima</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="101"/>
+        <location filename="previewdialog.cpp" line="181"/>
         <source>Approximate preview — rEFInd&apos;s real rendering also depends on the firmware resolution and theme.</source>
         <translation>Anteprima approssimativa — la resa reale di rEFInd dipende anche dalla risoluzione del firmware e dal tema.</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="107"/>
+        <location filename="previewdialog.cpp" line="184"/>
+        <source>Approximate preview showing the randomly picked &quot;%1&quot; theme — Random picks a theme anew each time the config is created.</source>
+        <translation>Anteprima approssimativa con il tema &quot;%1&quot; scelto a caso — &quot;Casuale&quot; sceglie un nuovo tema a ogni creazione della configurazione.</translation>
+    </message>
+    <message>
+        <location filename="previewdialog.cpp" line="188"/>
+        <source>Approximate preview with the &quot;%1&quot; theme applied — rEFInd&apos;s real rendering also depends on the firmware resolution and the theme&apos;s other settings.</source>
+        <translation>Anteprima approssimativa con il tema &quot;%1&quot; applicato — la resa reale di rEFInd dipende anche dalla risoluzione del firmware e dalle altre impostazioni del tema.</translation>
+    </message>
+    <message>
+        <location filename="previewdialog.cpp" line="197"/>
         <source>Boot screen</source>
         <translation>Schermata di avvio</translation>
     </message>

--- a/GUI/src/SteamDeck_rEFInd_ja.ts
+++ b/GUI/src/SteamDeck_rEFInd_ja.ts
@@ -120,7 +120,7 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="468"/>
-        <location filename="mainwindow.cpp" line="1590"/>
+        <location filename="mainwindow.cpp" line="1613"/>
         <source>Open Folder</source>
         <translation>フォルダーを開く</translation>
     </message>
@@ -280,9 +280,9 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="965"/>
-        <location filename="mainwindow.cpp" line="1545"/>
-        <location filename="mainwindow.cpp" line="1560"/>
-        <location filename="mainwindow.cpp" line="1565"/>
+        <location filename="mainwindow.cpp" line="1568"/>
+        <location filename="mainwindow.cpp" line="1583"/>
+        <location filename="mainwindow.cpp" line="1588"/>
         <source>Install Themes</source>
         <translation>テーマをインストール</translation>
     </message>
@@ -325,10 +325,10 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="1080"/>
-        <location filename="mainwindow.cpp" line="1086"/>
-        <location filename="mainwindow.cpp" line="1104"/>
-        <location filename="mainwindow.cpp" line="1110"/>
-        <location filename="mainwindow.cpp" line="1115"/>
+        <location filename="mainwindow.cpp" line="1109"/>
+        <location filename="mainwindow.cpp" line="1127"/>
+        <location filename="mainwindow.cpp" line="1133"/>
+        <location filename="mainwindow.cpp" line="1138"/>
         <source>Install Config</source>
         <translation>設定をインストール</translation>
     </message>
@@ -491,7 +491,7 @@
         <translation>%1 を完全に書き込めませんでした — ディスクが満杯の可能性があります。設定は更新されませんでした。</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1087"/>
+        <location filename="mainwindow.cpp" line="1110"/>
         <source>The config-install script was NOT run:
 
 %1
@@ -508,18 +508,18 @@ Reinstall the GUI to restore the original script, then try again.</source>
 GUI を再インストールして元のスクリプトを復元し、もう一度お試しください。</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1105"/>
-        <location filename="mainwindow.cpp" line="1117"/>
+        <location filename="mainwindow.cpp" line="1128"/>
+        <location filename="mainwindow.cpp" line="1140"/>
         <source>Installing the config failed (code %1).</source>
         <translation>設定のインストールに失敗しました（コード %1）。</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1112"/>
+        <location filename="mainwindow.cpp" line="1135"/>
         <source>The config was installed successfully.</source>
         <translation>設定は正常にインストールされました。</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1113"/>
+        <location filename="mainwindow.cpp" line="1136"/>
         <source>The config was installed successfully.
 
 %1</source>
@@ -528,7 +528,7 @@ GUI を再インストールして元のスクリプトを復元し、もう一�
 %1</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1118"/>
+        <location filename="mainwindow.cpp" line="1141"/>
         <source>Installing the config failed (code %1).
 
 %2</source>
@@ -537,28 +537,28 @@ GUI を再インストールして元のスクリプトを復元し、もう一�
 %2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1138"/>
-        <location filename="mainwindow.cpp" line="1148"/>
-        <location filename="mainwindow.cpp" line="1155"/>
+        <location filename="mainwindow.cpp" line="1161"/>
+        <location filename="mainwindow.cpp" line="1171"/>
+        <location filename="mainwindow.cpp" line="1178"/>
         <source>Copy PNG</source>
         <translation>PNG をコピー</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="935"/>
         <location filename="mainwindow.cpp" line="944"/>
-        <location filename="mainwindow.cpp" line="1139"/>
-        <location filename="mainwindow.cpp" line="1149"/>
-        <location filename="mainwindow.cpp" line="1156"/>
+        <location filename="mainwindow.cpp" line="1162"/>
+        <location filename="mainwindow.cpp" line="1172"/>
+        <location filename="mainwindow.cpp" line="1179"/>
         <source>Could not copy %1 to %2</source>
         <translation>%1 を %2 にコピーできませんでした</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1181"/>
+        <location filename="mainwindow.cpp" line="1204"/>
         <source>Invalid PNG</source>
         <translation>無効な PNG</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1182"/>
+        <location filename="mainwindow.cpp" line="1205"/>
         <source>%1 is not a valid PNG file.
 
 Backgrounds and OS icons must be real PNG images (not just files with a .png extension).</source>
@@ -567,58 +567,58 @@ Backgrounds and OS icons must be real PNG images (not just files with a .png ext
 背景と OS アイコンは、実際の PNG 画像である必要があります（拡張子が .png なだけのファイルは不可）。</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1445"/>
+        <location filename="mainwindow.cpp" line="1468"/>
         <source>Check For Update</source>
         <translation>更新を確認</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1448"/>
+        <location filename="mainwindow.cpp" line="1471"/>
         <source>&lt;p align=&apos;center&apos;&gt;&lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd&apos;&gt;rEFInd Customization GUI v%1&lt;/a&gt;&lt;br&gt;&lt;br&gt;Original GUI Creator: &lt;a href=&apos;https://github.com/jlobue10&apos;&gt;jlobue10&lt;/a&gt;&lt;br&gt;&lt;br&gt;Special Thanks to Deck Wizard for testing and QA&lt;br&gt;&lt;br&gt;&lt;a href=&apos;https://www.youtube.com/watch?v=yBHzVSDVEqw&apos;&gt;Deck Wizard Dual Boot Tutorial&lt;/a&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;&lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd&apos;&gt;rEFInd Customization GUI v%1&lt;/a&gt;&lt;br&gt;&lt;br&gt;オリジナル GUI 作者: &lt;a href=&apos;https://github.com/jlobue10&apos;&gt;jlobue10&lt;/a&gt;&lt;br&gt;&lt;br&gt;テストと QA を担当した Deck Wizard に感謝します&lt;br&gt;&lt;br&gt;&lt;a href=&apos;https://www.youtube.com/watch?v=yBHzVSDVEqw&apos;&gt;Deck Wizard デュアルブートチュートリアル&lt;/a&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1497"/>
+        <location filename="mainwindow.cpp" line="1520"/>
         <source>&lt;p align=&apos;center&apos;&gt;Update check failed. Please check your internet connection and try again.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;更新の確認に失敗しました。インターネット接続を確認して、もう一度お試しください。&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1500"/>
+        <location filename="mainwindow.cpp" line="1523"/>
         <source>&lt;p align=&apos;center&apos;&gt;An update is available &lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd/releases&apos;&gt;here&lt;/a&gt;&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;更新があります。&lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd/releases&apos;&gt;こちら&lt;/a&gt;から入手できます&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1504"/>
+        <location filename="mainwindow.cpp" line="1527"/>
         <source>&lt;p align=&apos;center&apos;&gt;No update found. You are using the latest version.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;更新はありません。最新バージョンを使用しています。&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1514"/>
-        <location filename="mainwindow.cpp" line="1521"/>
+        <location filename="mainwindow.cpp" line="1537"/>
+        <location filename="mainwindow.cpp" line="1544"/>
         <source>systemd service</source>
         <translation>systemd サービス</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1515"/>
-        <location filename="mainwindow.cpp" line="1522"/>
+        <location filename="mainwindow.cpp" line="1538"/>
+        <location filename="mainwindow.cpp" line="1545"/>
         <source>Failed to launch the service toggle.</source>
         <translation>サービスの切り替えを起動できませんでした。</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1528"/>
-        <location filename="mainwindow.cpp" line="1535"/>
+        <location filename="mainwindow.cpp" line="1551"/>
+        <location filename="mainwindow.cpp" line="1558"/>
         <source>Background Randomizer</source>
         <translation>背景ランダム化</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1529"/>
-        <location filename="mainwindow.cpp" line="1536"/>
-        <location filename="mainwindow.cpp" line="1577"/>
-        <location filename="mainwindow.cpp" line="1584"/>
+        <location filename="mainwindow.cpp" line="1552"/>
+        <location filename="mainwindow.cpp" line="1559"/>
+        <location filename="mainwindow.cpp" line="1600"/>
+        <location filename="mainwindow.cpp" line="1607"/>
         <source>Failed to launch the randomizer setup.</source>
         <translation>ランダム化の設定を起動できませんでした。</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1546"/>
+        <location filename="mainwindow.cpp" line="1569"/>
         <source>The themes-install script was NOT run:
 
 %1
@@ -635,12 +635,12 @@ Reinstall the GUI (on SteamOS, re-run install-GUI.sh) to install or restore it, 
 GUI を再インストール（SteamOS では install-GUI.sh を再実行）してスクリプトをインストールまたは復元し、もう一度お試しください。</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1562"/>
+        <location filename="mainwindow.cpp" line="1585"/>
         <source>The themes were installed successfully.</source>
         <translation>テーマは正常にインストールされました。</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1563"/>
+        <location filename="mainwindow.cpp" line="1586"/>
         <source>The themes were installed successfully.
 
 %1</source>
@@ -649,12 +649,12 @@ GUI を再インストール（SteamOS では install-GUI.sh を再実行）し�
 %1</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1567"/>
+        <location filename="mainwindow.cpp" line="1590"/>
         <source>Installing the themes failed (code %1).</source>
         <translation>テーマのインストールに失敗しました（コード %1）。</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1568"/>
+        <location filename="mainwindow.cpp" line="1591"/>
         <source>Installing the themes failed (code %1).
 
 %2</source>
@@ -663,13 +663,13 @@ GUI を再インストール（SteamOS では install-GUI.sh を再実行）し�
 %2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1576"/>
-        <location filename="mainwindow.cpp" line="1583"/>
+        <location filename="mainwindow.cpp" line="1599"/>
+        <location filename="mainwindow.cpp" line="1606"/>
         <source>Theme Randomizer</source>
         <translation>テーマランダム化</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1591"/>
+        <location filename="mainwindow.cpp" line="1614"/>
         <source>Failed to open %1 in the file manager.</source>
         <translation>ファイルマネージャーで %1 を開けませんでした。</translation>
     </message>
@@ -696,22 +696,32 @@ GUI を再インストール（SteamOS では install-GUI.sh を再実行）し�
 <context>
     <name>PreviewDialog</name>
     <message>
-        <location filename="previewdialog.cpp" line="34"/>
+        <location filename="previewdialog.cpp" line="62"/>
         <source>No boot options selected.</source>
         <translation>起動オプションが選択されていません。</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="89"/>
+        <location filename="previewdialog.cpp" line="166"/>
         <source>Preview</source>
         <translation>プレビュー</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="101"/>
+        <location filename="previewdialog.cpp" line="181"/>
         <source>Approximate preview — rEFInd&apos;s real rendering also depends on the firmware resolution and theme.</source>
         <translation>おおよそのプレビューです — rEFInd の実際の表示はファームウェアの解像度やテーマにも依存します。</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="107"/>
+        <location filename="previewdialog.cpp" line="184"/>
+        <source>Approximate preview showing the randomly picked &quot;%1&quot; theme — Random picks a theme anew each time the config is created.</source>
+        <translation>ランダムに選ばれたテーマ「%1」を表示するおおよそのプレビューです — 「ランダム」は構成を作成するたびに新しいテーマを選びます。</translation>
+    </message>
+    <message>
+        <location filename="previewdialog.cpp" line="188"/>
+        <source>Approximate preview with the &quot;%1&quot; theme applied — rEFInd&apos;s real rendering also depends on the firmware resolution and the theme&apos;s other settings.</source>
+        <translation>テーマ「%1」を適用したおおよそのプレビューです — rEFInd の実際の表示はファームウェアの解像度やテーマのその他の設定にも依存します。</translation>
+    </message>
+    <message>
+        <location filename="previewdialog.cpp" line="197"/>
         <source>Boot screen</source>
         <translation>起動画面</translation>
     </message>

--- a/GUI/src/SteamDeck_rEFInd_ko.ts
+++ b/GUI/src/SteamDeck_rEFInd_ko.ts
@@ -120,7 +120,7 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="468"/>
-        <location filename="mainwindow.cpp" line="1590"/>
+        <location filename="mainwindow.cpp" line="1613"/>
         <source>Open Folder</source>
         <translation>폴더 열기</translation>
     </message>
@@ -280,9 +280,9 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="965"/>
-        <location filename="mainwindow.cpp" line="1545"/>
-        <location filename="mainwindow.cpp" line="1560"/>
-        <location filename="mainwindow.cpp" line="1565"/>
+        <location filename="mainwindow.cpp" line="1568"/>
+        <location filename="mainwindow.cpp" line="1583"/>
+        <location filename="mainwindow.cpp" line="1588"/>
         <source>Install Themes</source>
         <translation>테마 설치</translation>
     </message>
@@ -325,10 +325,10 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="1080"/>
-        <location filename="mainwindow.cpp" line="1086"/>
-        <location filename="mainwindow.cpp" line="1104"/>
-        <location filename="mainwindow.cpp" line="1110"/>
-        <location filename="mainwindow.cpp" line="1115"/>
+        <location filename="mainwindow.cpp" line="1109"/>
+        <location filename="mainwindow.cpp" line="1127"/>
+        <location filename="mainwindow.cpp" line="1133"/>
+        <location filename="mainwindow.cpp" line="1138"/>
         <source>Install Config</source>
         <translation>구성 설치</translation>
     </message>
@@ -491,7 +491,7 @@
         <translation>%1을(를) 완전히 쓸 수 없습니다 — 디스크가 가득 찼을 수 있습니다. 구성은 업데이트되지 않았습니다.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1087"/>
+        <location filename="mainwindow.cpp" line="1110"/>
         <source>The config-install script was NOT run:
 
 %1
@@ -508,18 +508,18 @@ Reinstall the GUI to restore the original script, then try again.</source>
 GUI를 다시 설치하여 원본 스크립트를 복원한 후 다시 시도하세요.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1105"/>
-        <location filename="mainwindow.cpp" line="1117"/>
+        <location filename="mainwindow.cpp" line="1128"/>
+        <location filename="mainwindow.cpp" line="1140"/>
         <source>Installing the config failed (code %1).</source>
         <translation>구성 설치에 실패했습니다(코드 %1).</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1112"/>
+        <location filename="mainwindow.cpp" line="1135"/>
         <source>The config was installed successfully.</source>
         <translation>구성이 성공적으로 설치되었습니다.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1113"/>
+        <location filename="mainwindow.cpp" line="1136"/>
         <source>The config was installed successfully.
 
 %1</source>
@@ -528,7 +528,7 @@ GUI를 다시 설치하여 원본 스크립트를 복원한 후 다시 시도하
 %1</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1118"/>
+        <location filename="mainwindow.cpp" line="1141"/>
         <source>Installing the config failed (code %1).
 
 %2</source>
@@ -537,28 +537,28 @@ GUI를 다시 설치하여 원본 스크립트를 복원한 후 다시 시도하
 %2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1138"/>
-        <location filename="mainwindow.cpp" line="1148"/>
-        <location filename="mainwindow.cpp" line="1155"/>
+        <location filename="mainwindow.cpp" line="1161"/>
+        <location filename="mainwindow.cpp" line="1171"/>
+        <location filename="mainwindow.cpp" line="1178"/>
         <source>Copy PNG</source>
         <translation>PNG 복사</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="935"/>
         <location filename="mainwindow.cpp" line="944"/>
-        <location filename="mainwindow.cpp" line="1139"/>
-        <location filename="mainwindow.cpp" line="1149"/>
-        <location filename="mainwindow.cpp" line="1156"/>
+        <location filename="mainwindow.cpp" line="1162"/>
+        <location filename="mainwindow.cpp" line="1172"/>
+        <location filename="mainwindow.cpp" line="1179"/>
         <source>Could not copy %1 to %2</source>
         <translation>%1을(를) %2(으)로 복사할 수 없습니다</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1181"/>
+        <location filename="mainwindow.cpp" line="1204"/>
         <source>Invalid PNG</source>
         <translation>잘못된 PNG</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1182"/>
+        <location filename="mainwindow.cpp" line="1205"/>
         <source>%1 is not a valid PNG file.
 
 Backgrounds and OS icons must be real PNG images (not just files with a .png extension).</source>
@@ -567,58 +567,58 @@ Backgrounds and OS icons must be real PNG images (not just files with a .png ext
 배경과 OS 아이콘은 실제 PNG 이미지여야 합니다(.png 확장자만 있는 파일이 아니라).</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1445"/>
+        <location filename="mainwindow.cpp" line="1468"/>
         <source>Check For Update</source>
         <translation>업데이트 확인</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1448"/>
+        <location filename="mainwindow.cpp" line="1471"/>
         <source>&lt;p align=&apos;center&apos;&gt;&lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd&apos;&gt;rEFInd Customization GUI v%1&lt;/a&gt;&lt;br&gt;&lt;br&gt;Original GUI Creator: &lt;a href=&apos;https://github.com/jlobue10&apos;&gt;jlobue10&lt;/a&gt;&lt;br&gt;&lt;br&gt;Special Thanks to Deck Wizard for testing and QA&lt;br&gt;&lt;br&gt;&lt;a href=&apos;https://www.youtube.com/watch?v=yBHzVSDVEqw&apos;&gt;Deck Wizard Dual Boot Tutorial&lt;/a&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;&lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd&apos;&gt;rEFInd Customization GUI v%1&lt;/a&gt;&lt;br&gt;&lt;br&gt;최초 GUI 제작자: &lt;a href=&apos;https://github.com/jlobue10&apos;&gt;jlobue10&lt;/a&gt;&lt;br&gt;&lt;br&gt;테스트와 QA를 맡아 준 Deck Wizard에게 특별히 감사드립니다&lt;br&gt;&lt;br&gt;&lt;a href=&apos;https://www.youtube.com/watch?v=yBHzVSDVEqw&apos;&gt;Deck Wizard 듀얼 부팅 튜토리얼&lt;/a&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1497"/>
+        <location filename="mainwindow.cpp" line="1520"/>
         <source>&lt;p align=&apos;center&apos;&gt;Update check failed. Please check your internet connection and try again.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;업데이트 확인에 실패했습니다. 인터넷 연결을 확인한 후 다시 시도하세요.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1500"/>
+        <location filename="mainwindow.cpp" line="1523"/>
         <source>&lt;p align=&apos;center&apos;&gt;An update is available &lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd/releases&apos;&gt;here&lt;/a&gt;&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;업데이트가 있습니다. &lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd/releases&apos;&gt;여기&lt;/a&gt;에서 받을 수 있습니다&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1504"/>
+        <location filename="mainwindow.cpp" line="1527"/>
         <source>&lt;p align=&apos;center&apos;&gt;No update found. You are using the latest version.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;업데이트가 없습니다. 최신 버전을 사용 중입니다.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1514"/>
-        <location filename="mainwindow.cpp" line="1521"/>
+        <location filename="mainwindow.cpp" line="1537"/>
+        <location filename="mainwindow.cpp" line="1544"/>
         <source>systemd service</source>
         <translation>systemd 서비스</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1515"/>
-        <location filename="mainwindow.cpp" line="1522"/>
+        <location filename="mainwindow.cpp" line="1538"/>
+        <location filename="mainwindow.cpp" line="1545"/>
         <source>Failed to launch the service toggle.</source>
         <translation>서비스 전환을 시작하지 못했습니다.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1528"/>
-        <location filename="mainwindow.cpp" line="1535"/>
+        <location filename="mainwindow.cpp" line="1551"/>
+        <location filename="mainwindow.cpp" line="1558"/>
         <source>Background Randomizer</source>
         <translation>배경 무작위 변경</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1529"/>
-        <location filename="mainwindow.cpp" line="1536"/>
-        <location filename="mainwindow.cpp" line="1577"/>
-        <location filename="mainwindow.cpp" line="1584"/>
+        <location filename="mainwindow.cpp" line="1552"/>
+        <location filename="mainwindow.cpp" line="1559"/>
+        <location filename="mainwindow.cpp" line="1600"/>
+        <location filename="mainwindow.cpp" line="1607"/>
         <source>Failed to launch the randomizer setup.</source>
         <translation>무작위 배경 설정을 시작하지 못했습니다.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1546"/>
+        <location filename="mainwindow.cpp" line="1569"/>
         <source>The themes-install script was NOT run:
 
 %1
@@ -635,12 +635,12 @@ Reinstall the GUI (on SteamOS, re-run install-GUI.sh) to install or restore it, 
 GUI를 다시 설치(SteamOS에서는 install-GUI.sh 재실행)하여 스크립트를 설치하거나 복원한 후 다시 시도하세요.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1562"/>
+        <location filename="mainwindow.cpp" line="1585"/>
         <source>The themes were installed successfully.</source>
         <translation>테마가 성공적으로 설치되었습니다.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1563"/>
+        <location filename="mainwindow.cpp" line="1586"/>
         <source>The themes were installed successfully.
 
 %1</source>
@@ -649,12 +649,12 @@ GUI를 다시 설치(SteamOS에서는 install-GUI.sh 재실행)하여 스크립�
 %1</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1567"/>
+        <location filename="mainwindow.cpp" line="1590"/>
         <source>Installing the themes failed (code %1).</source>
         <translation>테마 설치에 실패했습니다(코드 %1).</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1568"/>
+        <location filename="mainwindow.cpp" line="1591"/>
         <source>Installing the themes failed (code %1).
 
 %2</source>
@@ -663,13 +663,13 @@ GUI를 다시 설치(SteamOS에서는 install-GUI.sh 재실행)하여 스크립�
 %2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1576"/>
-        <location filename="mainwindow.cpp" line="1583"/>
+        <location filename="mainwindow.cpp" line="1599"/>
+        <location filename="mainwindow.cpp" line="1606"/>
         <source>Theme Randomizer</source>
         <translation>테마 무작위 변경</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1591"/>
+        <location filename="mainwindow.cpp" line="1614"/>
         <source>Failed to open %1 in the file manager.</source>
         <translation>파일 관리자에서 %1을(를) 열지 못했습니다.</translation>
     </message>
@@ -696,22 +696,32 @@ GUI를 다시 설치(SteamOS에서는 install-GUI.sh 재실행)하여 스크립�
 <context>
     <name>PreviewDialog</name>
     <message>
-        <location filename="previewdialog.cpp" line="34"/>
+        <location filename="previewdialog.cpp" line="62"/>
         <source>No boot options selected.</source>
         <translation>선택된 부팅 옵션이 없습니다.</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="89"/>
+        <location filename="previewdialog.cpp" line="166"/>
         <source>Preview</source>
         <translation>미리보기</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="101"/>
+        <location filename="previewdialog.cpp" line="181"/>
         <source>Approximate preview — rEFInd&apos;s real rendering also depends on the firmware resolution and theme.</source>
         <translation>대략적인 미리보기입니다 — rEFInd의 실제 표시는 펌웨어 해상도와 테마에도 따라 달라집니다.</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="107"/>
+        <location filename="previewdialog.cpp" line="184"/>
+        <source>Approximate preview showing the randomly picked &quot;%1&quot; theme — Random picks a theme anew each time the config is created.</source>
+        <translation>무작위로 선택된 &quot;%1&quot; 테마를 보여주는 대략적인 미리보기입니다 — &quot;무작위&quot;는 구성을 만들 때마다 새 테마를 선택합니다.</translation>
+    </message>
+    <message>
+        <location filename="previewdialog.cpp" line="188"/>
+        <source>Approximate preview with the &quot;%1&quot; theme applied — rEFInd&apos;s real rendering also depends on the firmware resolution and the theme&apos;s other settings.</source>
+        <translation>&quot;%1&quot; 테마가 적용된 대략적인 미리보기입니다 — rEFInd의 실제 표시는 펌웨어 해상도와 테마의 다른 설정에도 따라 달라집니다.</translation>
+    </message>
+    <message>
+        <location filename="previewdialog.cpp" line="197"/>
         <source>Boot screen</source>
         <translation>부팅 화면</translation>
     </message>

--- a/GUI/src/SteamDeck_rEFInd_nl.ts
+++ b/GUI/src/SteamDeck_rEFInd_nl.ts
@@ -130,7 +130,7 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="468"/>
-        <location filename="mainwindow.cpp" line="1590"/>
+        <location filename="mainwindow.cpp" line="1613"/>
         <source>Open Folder</source>
         <translation>Map openen</translation>
     </message>
@@ -276,9 +276,9 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="965"/>
-        <location filename="mainwindow.cpp" line="1545"/>
-        <location filename="mainwindow.cpp" line="1560"/>
-        <location filename="mainwindow.cpp" line="1565"/>
+        <location filename="mainwindow.cpp" line="1568"/>
+        <location filename="mainwindow.cpp" line="1583"/>
+        <location filename="mainwindow.cpp" line="1588"/>
         <source>Install Themes</source>
         <translation>Thema&apos;s installeren</translation>
     </message>
@@ -321,10 +321,10 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="1080"/>
-        <location filename="mainwindow.cpp" line="1086"/>
-        <location filename="mainwindow.cpp" line="1104"/>
-        <location filename="mainwindow.cpp" line="1110"/>
-        <location filename="mainwindow.cpp" line="1115"/>
+        <location filename="mainwindow.cpp" line="1109"/>
+        <location filename="mainwindow.cpp" line="1127"/>
+        <location filename="mainwindow.cpp" line="1133"/>
+        <location filename="mainwindow.cpp" line="1138"/>
         <source>Install Config</source>
         <translation>Config installeren</translation>
     </message>
@@ -487,7 +487,7 @@
         <translation>Kon %1 niet volledig wegschrijven — de schijf is mogelijk vol. De config is niet bijgewerkt.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1087"/>
+        <location filename="mainwindow.cpp" line="1110"/>
         <source>The config-install script was NOT run:
 
 %1
@@ -504,18 +504,18 @@ Het komt niet overeen met de kopie die met deze versie van de app is meegeleverd
 Installeer de GUI opnieuw om het originele script te herstellen en probeer het daarna nogmaals.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1105"/>
-        <location filename="mainwindow.cpp" line="1117"/>
+        <location filename="mainwindow.cpp" line="1128"/>
+        <location filename="mainwindow.cpp" line="1140"/>
         <source>Installing the config failed (code %1).</source>
         <translation>Het installeren van de config is mislukt (code %1).</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1112"/>
+        <location filename="mainwindow.cpp" line="1135"/>
         <source>The config was installed successfully.</source>
         <translation>De config is met succes geïnstalleerd.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1113"/>
+        <location filename="mainwindow.cpp" line="1136"/>
         <source>The config was installed successfully.
 
 %1</source>
@@ -524,7 +524,7 @@ Installeer de GUI opnieuw om het originele script te herstellen en probeer het d
 %1</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1118"/>
+        <location filename="mainwindow.cpp" line="1141"/>
         <source>Installing the config failed (code %1).
 
 %2</source>
@@ -533,28 +533,28 @@ Installeer de GUI opnieuw om het originele script te herstellen en probeer het d
 %2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1138"/>
-        <location filename="mainwindow.cpp" line="1148"/>
-        <location filename="mainwindow.cpp" line="1155"/>
+        <location filename="mainwindow.cpp" line="1161"/>
+        <location filename="mainwindow.cpp" line="1171"/>
+        <location filename="mainwindow.cpp" line="1178"/>
         <source>Copy PNG</source>
         <translation>PNG kopiëren</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="935"/>
         <location filename="mainwindow.cpp" line="944"/>
-        <location filename="mainwindow.cpp" line="1139"/>
-        <location filename="mainwindow.cpp" line="1149"/>
-        <location filename="mainwindow.cpp" line="1156"/>
+        <location filename="mainwindow.cpp" line="1162"/>
+        <location filename="mainwindow.cpp" line="1172"/>
+        <location filename="mainwindow.cpp" line="1179"/>
         <source>Could not copy %1 to %2</source>
         <translation>Kon %1 niet naar %2 kopiëren</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1181"/>
+        <location filename="mainwindow.cpp" line="1204"/>
         <source>Invalid PNG</source>
         <translation>Ongeldige PNG</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1182"/>
+        <location filename="mainwindow.cpp" line="1205"/>
         <source>%1 is not a valid PNG file.
 
 Backgrounds and OS icons must be real PNG images (not just files with a .png extension).</source>
@@ -563,58 +563,58 @@ Backgrounds and OS icons must be real PNG images (not just files with a .png ext
 Achtergronden en OS-pictogrammen moeten echte PNG-afbeeldingen zijn (niet slechts bestanden met de extensie .png).</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1445"/>
+        <location filename="mainwindow.cpp" line="1468"/>
         <source>Check For Update</source>
         <translation>Controleren op updates</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1448"/>
+        <location filename="mainwindow.cpp" line="1471"/>
         <source>&lt;p align=&apos;center&apos;&gt;&lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd&apos;&gt;rEFInd Customization GUI v%1&lt;/a&gt;&lt;br&gt;&lt;br&gt;Original GUI Creator: &lt;a href=&apos;https://github.com/jlobue10&apos;&gt;jlobue10&lt;/a&gt;&lt;br&gt;&lt;br&gt;Special Thanks to Deck Wizard for testing and QA&lt;br&gt;&lt;br&gt;&lt;a href=&apos;https://www.youtube.com/watch?v=yBHzVSDVEqw&apos;&gt;Deck Wizard Dual Boot Tutorial&lt;/a&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;&lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd&apos;&gt;rEFInd Customization GUI v%1&lt;/a&gt;&lt;br&gt;&lt;br&gt;Oorspronkelijke maker van de GUI: &lt;a href=&apos;https://github.com/jlobue10&apos;&gt;jlobue10&lt;/a&gt;&lt;br&gt;&lt;br&gt;Met speciale dank aan Deck Wizard voor het testen en de kwaliteitscontrole&lt;br&gt;&lt;br&gt;&lt;a href=&apos;https://www.youtube.com/watch?v=yBHzVSDVEqw&apos;&gt;Dual-boot-tutorial van Deck Wizard&lt;/a&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1497"/>
+        <location filename="mainwindow.cpp" line="1520"/>
         <source>&lt;p align=&apos;center&apos;&gt;Update check failed. Please check your internet connection and try again.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;De updatecontrole is mislukt. Controleer je internetverbinding en probeer het opnieuw.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1500"/>
+        <location filename="mainwindow.cpp" line="1523"/>
         <source>&lt;p align=&apos;center&apos;&gt;An update is available &lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd/releases&apos;&gt;here&lt;/a&gt;&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;Er is een update beschikbaar &lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd/releases&apos;&gt;hier&lt;/a&gt;&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1504"/>
+        <location filename="mainwindow.cpp" line="1527"/>
         <source>&lt;p align=&apos;center&apos;&gt;No update found. You are using the latest version.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;Geen update gevonden. Je gebruikt de nieuwste versie.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1514"/>
-        <location filename="mainwindow.cpp" line="1521"/>
+        <location filename="mainwindow.cpp" line="1537"/>
+        <location filename="mainwindow.cpp" line="1544"/>
         <source>systemd service</source>
         <translation>systemd-service</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1515"/>
-        <location filename="mainwindow.cpp" line="1522"/>
+        <location filename="mainwindow.cpp" line="1538"/>
+        <location filename="mainwindow.cpp" line="1545"/>
         <source>Failed to launch the service toggle.</source>
         <translation>Kon het omschakelen van de service niet starten.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1528"/>
-        <location filename="mainwindow.cpp" line="1535"/>
+        <location filename="mainwindow.cpp" line="1551"/>
+        <location filename="mainwindow.cpp" line="1558"/>
         <source>Background Randomizer</source>
         <translation>Achtergrondrandomizer</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1529"/>
-        <location filename="mainwindow.cpp" line="1536"/>
-        <location filename="mainwindow.cpp" line="1577"/>
-        <location filename="mainwindow.cpp" line="1584"/>
+        <location filename="mainwindow.cpp" line="1552"/>
+        <location filename="mainwindow.cpp" line="1559"/>
+        <location filename="mainwindow.cpp" line="1600"/>
+        <location filename="mainwindow.cpp" line="1607"/>
         <source>Failed to launch the randomizer setup.</source>
         <translation>Kon de randomizer-instelling niet starten.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1546"/>
+        <location filename="mainwindow.cpp" line="1569"/>
         <source>The themes-install script was NOT run:
 
 %1
@@ -631,12 +631,12 @@ Het ontbreekt, of het komt niet overeen met de kopie die met deze versie van de 
 Installeer de GUI opnieuw (op SteamOS: voer install-GUI.sh opnieuw uit) om het te installeren of te herstellen en probeer het daarna nogmaals.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1562"/>
+        <location filename="mainwindow.cpp" line="1585"/>
         <source>The themes were installed successfully.</source>
         <translation>De thema&apos;s zijn met succes geïnstalleerd.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1563"/>
+        <location filename="mainwindow.cpp" line="1586"/>
         <source>The themes were installed successfully.
 
 %1</source>
@@ -645,12 +645,12 @@ Installeer de GUI opnieuw (op SteamOS: voer install-GUI.sh opnieuw uit) om het t
 %1</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1567"/>
+        <location filename="mainwindow.cpp" line="1590"/>
         <source>Installing the themes failed (code %1).</source>
         <translation>Het installeren van de thema&apos;s is mislukt (code %1).</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1568"/>
+        <location filename="mainwindow.cpp" line="1591"/>
         <source>Installing the themes failed (code %1).
 
 %2</source>
@@ -659,13 +659,13 @@ Installeer de GUI opnieuw (op SteamOS: voer install-GUI.sh opnieuw uit) om het t
 %2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1576"/>
-        <location filename="mainwindow.cpp" line="1583"/>
+        <location filename="mainwindow.cpp" line="1599"/>
+        <location filename="mainwindow.cpp" line="1606"/>
         <source>Theme Randomizer</source>
         <translation>Themarandomizer</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1591"/>
+        <location filename="mainwindow.cpp" line="1614"/>
         <source>Failed to open %1 in the file manager.</source>
         <translation>Kon %1 niet openen in de bestandsbeheerder.</translation>
     </message>
@@ -692,22 +692,32 @@ Installeer de GUI opnieuw (op SteamOS: voer install-GUI.sh opnieuw uit) om het t
 <context>
     <name>PreviewDialog</name>
     <message>
-        <location filename="previewdialog.cpp" line="34"/>
+        <location filename="previewdialog.cpp" line="62"/>
         <source>No boot options selected.</source>
         <translation>Geen opstartopties geselecteerd.</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="89"/>
+        <location filename="previewdialog.cpp" line="166"/>
         <source>Preview</source>
         <translation>Voorbeeld</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="101"/>
+        <location filename="previewdialog.cpp" line="181"/>
         <source>Approximate preview — rEFInd&apos;s real rendering also depends on the firmware resolution and theme.</source>
         <translation>Benaderend voorbeeld — de werkelijke weergave van rEFInd hangt ook af van de firmwareresolutie en het thema.</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="107"/>
+        <location filename="previewdialog.cpp" line="184"/>
+        <source>Approximate preview showing the randomly picked &quot;%1&quot; theme — Random picks a theme anew each time the config is created.</source>
+        <translation>Benaderend voorbeeld met het willekeurig gekozen thema &quot;%1&quot; — &quot;Willekeurig&quot; kiest telkens een nieuw thema wanneer de configuratie wordt aangemaakt.</translation>
+    </message>
+    <message>
+        <location filename="previewdialog.cpp" line="188"/>
+        <source>Approximate preview with the &quot;%1&quot; theme applied — rEFInd&apos;s real rendering also depends on the firmware resolution and the theme&apos;s other settings.</source>
+        <translation>Benaderend voorbeeld met het thema &quot;%1&quot; toegepast — de werkelijke weergave van rEFInd hangt ook af van de firmwareresolutie en de overige instellingen van het thema.</translation>
+    </message>
+    <message>
+        <location filename="previewdialog.cpp" line="197"/>
         <source>Boot screen</source>
         <translation>Opstartscherm</translation>
     </message>

--- a/GUI/src/SteamDeck_rEFInd_pt.ts
+++ b/GUI/src/SteamDeck_rEFInd_pt.ts
@@ -120,7 +120,7 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="468"/>
-        <location filename="mainwindow.cpp" line="1590"/>
+        <location filename="mainwindow.cpp" line="1613"/>
         <source>Open Folder</source>
         <translation>Abrir pasta</translation>
     </message>
@@ -280,9 +280,9 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="965"/>
-        <location filename="mainwindow.cpp" line="1545"/>
-        <location filename="mainwindow.cpp" line="1560"/>
-        <location filename="mainwindow.cpp" line="1565"/>
+        <location filename="mainwindow.cpp" line="1568"/>
+        <location filename="mainwindow.cpp" line="1583"/>
+        <location filename="mainwindow.cpp" line="1588"/>
         <source>Install Themes</source>
         <translation>Instalar temas</translation>
     </message>
@@ -325,10 +325,10 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="1080"/>
-        <location filename="mainwindow.cpp" line="1086"/>
-        <location filename="mainwindow.cpp" line="1104"/>
-        <location filename="mainwindow.cpp" line="1110"/>
-        <location filename="mainwindow.cpp" line="1115"/>
+        <location filename="mainwindow.cpp" line="1109"/>
+        <location filename="mainwindow.cpp" line="1127"/>
+        <location filename="mainwindow.cpp" line="1133"/>
+        <location filename="mainwindow.cpp" line="1138"/>
         <source>Install Config</source>
         <translation>Instalar config.</translation>
     </message>
@@ -491,7 +491,7 @@
         <translation>Não foi possível gravar %1 por completo — o disco pode estar cheio. A configuração não foi atualizada.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1087"/>
+        <location filename="mainwindow.cpp" line="1110"/>
         <source>The config-install script was NOT run:
 
 %1
@@ -508,18 +508,18 @@ Ele não corresponde à cópia fornecida com esta versão do aplicativo. Como é
 Reinstale a GUI para restaurar o script original e tente novamente.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1105"/>
-        <location filename="mainwindow.cpp" line="1117"/>
+        <location filename="mainwindow.cpp" line="1128"/>
+        <location filename="mainwindow.cpp" line="1140"/>
         <source>Installing the config failed (code %1).</source>
         <translation>A instalação da configuração falhou (código %1).</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1112"/>
+        <location filename="mainwindow.cpp" line="1135"/>
         <source>The config was installed successfully.</source>
         <translation>A configuração foi instalada com sucesso.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1113"/>
+        <location filename="mainwindow.cpp" line="1136"/>
         <source>The config was installed successfully.
 
 %1</source>
@@ -528,7 +528,7 @@ Reinstale a GUI para restaurar o script original e tente novamente.</translation
 %1</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1118"/>
+        <location filename="mainwindow.cpp" line="1141"/>
         <source>Installing the config failed (code %1).
 
 %2</source>
@@ -537,28 +537,28 @@ Reinstale a GUI para restaurar o script original e tente novamente.</translation
 %2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1138"/>
-        <location filename="mainwindow.cpp" line="1148"/>
-        <location filename="mainwindow.cpp" line="1155"/>
+        <location filename="mainwindow.cpp" line="1161"/>
+        <location filename="mainwindow.cpp" line="1171"/>
+        <location filename="mainwindow.cpp" line="1178"/>
         <source>Copy PNG</source>
         <translation>Copiar PNG</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="935"/>
         <location filename="mainwindow.cpp" line="944"/>
-        <location filename="mainwindow.cpp" line="1139"/>
-        <location filename="mainwindow.cpp" line="1149"/>
-        <location filename="mainwindow.cpp" line="1156"/>
+        <location filename="mainwindow.cpp" line="1162"/>
+        <location filename="mainwindow.cpp" line="1172"/>
+        <location filename="mainwindow.cpp" line="1179"/>
         <source>Could not copy %1 to %2</source>
         <translation>Não foi possível copiar %1 para %2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1181"/>
+        <location filename="mainwindow.cpp" line="1204"/>
         <source>Invalid PNG</source>
         <translation>PNG inválido</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1182"/>
+        <location filename="mainwindow.cpp" line="1205"/>
         <source>%1 is not a valid PNG file.
 
 Backgrounds and OS icons must be real PNG images (not just files with a .png extension).</source>
@@ -567,58 +567,58 @@ Backgrounds and OS icons must be real PNG images (not just files with a .png ext
 Planos de fundo e ícones de sistema devem ser imagens PNG reais (não apenas arquivos com extensão .png).</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1445"/>
+        <location filename="mainwindow.cpp" line="1468"/>
         <source>Check For Update</source>
         <translation>Verificar atualização</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1448"/>
+        <location filename="mainwindow.cpp" line="1471"/>
         <source>&lt;p align=&apos;center&apos;&gt;&lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd&apos;&gt;rEFInd Customization GUI v%1&lt;/a&gt;&lt;br&gt;&lt;br&gt;Original GUI Creator: &lt;a href=&apos;https://github.com/jlobue10&apos;&gt;jlobue10&lt;/a&gt;&lt;br&gt;&lt;br&gt;Special Thanks to Deck Wizard for testing and QA&lt;br&gt;&lt;br&gt;&lt;a href=&apos;https://www.youtube.com/watch?v=yBHzVSDVEqw&apos;&gt;Deck Wizard Dual Boot Tutorial&lt;/a&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;&lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd&apos;&gt;rEFInd Customization GUI v%1&lt;/a&gt;&lt;br&gt;&lt;br&gt;Criador original da GUI: &lt;a href=&apos;https://github.com/jlobue10&apos;&gt;jlobue10&lt;/a&gt;&lt;br&gt;&lt;br&gt;Agradecimento especial ao Deck Wizard pelos testes e controle de qualidade&lt;br&gt;&lt;br&gt;&lt;a href=&apos;https://www.youtube.com/watch?v=yBHzVSDVEqw&apos;&gt;Tutorial de dual boot do Deck Wizard&lt;/a&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1497"/>
+        <location filename="mainwindow.cpp" line="1520"/>
         <source>&lt;p align=&apos;center&apos;&gt;Update check failed. Please check your internet connection and try again.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;Falha ao verificar atualizações. Verifique sua conexão com a internet e tente novamente.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1500"/>
+        <location filename="mainwindow.cpp" line="1523"/>
         <source>&lt;p align=&apos;center&apos;&gt;An update is available &lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd/releases&apos;&gt;here&lt;/a&gt;&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;Há uma atualização disponível &lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd/releases&apos;&gt;aqui&lt;/a&gt;&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1504"/>
+        <location filename="mainwindow.cpp" line="1527"/>
         <source>&lt;p align=&apos;center&apos;&gt;No update found. You are using the latest version.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;Nenhuma atualização encontrada. Você está usando a versão mais recente.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1514"/>
-        <location filename="mainwindow.cpp" line="1521"/>
+        <location filename="mainwindow.cpp" line="1537"/>
+        <location filename="mainwindow.cpp" line="1544"/>
         <source>systemd service</source>
         <translation>Serviço systemd</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1515"/>
-        <location filename="mainwindow.cpp" line="1522"/>
+        <location filename="mainwindow.cpp" line="1538"/>
+        <location filename="mainwindow.cpp" line="1545"/>
         <source>Failed to launch the service toggle.</source>
         <translation>Falha ao iniciar a alternância do serviço.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1528"/>
-        <location filename="mainwindow.cpp" line="1535"/>
+        <location filename="mainwindow.cpp" line="1551"/>
+        <location filename="mainwindow.cpp" line="1558"/>
         <source>Background Randomizer</source>
         <translation>Plano de fundo aleatório</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1529"/>
-        <location filename="mainwindow.cpp" line="1536"/>
-        <location filename="mainwindow.cpp" line="1577"/>
-        <location filename="mainwindow.cpp" line="1584"/>
+        <location filename="mainwindow.cpp" line="1552"/>
+        <location filename="mainwindow.cpp" line="1559"/>
+        <location filename="mainwindow.cpp" line="1600"/>
+        <location filename="mainwindow.cpp" line="1607"/>
         <source>Failed to launch the randomizer setup.</source>
         <translation>Falha ao iniciar a configuração do plano de fundo aleatório.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1546"/>
+        <location filename="mainwindow.cpp" line="1569"/>
         <source>The themes-install script was NOT run:
 
 %1
@@ -635,12 +635,12 @@ Ele está ausente ou não corresponde à cópia fornecida com esta versão do ap
 Reinstale a GUI (no SteamOS, execute novamente o install-GUI.sh) para instalá-lo ou restaurá-lo e tente novamente.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1562"/>
+        <location filename="mainwindow.cpp" line="1585"/>
         <source>The themes were installed successfully.</source>
         <translation>Os temas foram instalados com sucesso.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1563"/>
+        <location filename="mainwindow.cpp" line="1586"/>
         <source>The themes were installed successfully.
 
 %1</source>
@@ -649,12 +649,12 @@ Reinstale a GUI (no SteamOS, execute novamente o install-GUI.sh) para instalá-l
 %1</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1567"/>
+        <location filename="mainwindow.cpp" line="1590"/>
         <source>Installing the themes failed (code %1).</source>
         <translation>A instalação dos temas falhou (código %1).</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1568"/>
+        <location filename="mainwindow.cpp" line="1591"/>
         <source>Installing the themes failed (code %1).
 
 %2</source>
@@ -663,13 +663,13 @@ Reinstale a GUI (no SteamOS, execute novamente o install-GUI.sh) para instalá-l
 %2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1576"/>
-        <location filename="mainwindow.cpp" line="1583"/>
+        <location filename="mainwindow.cpp" line="1599"/>
+        <location filename="mainwindow.cpp" line="1606"/>
         <source>Theme Randomizer</source>
         <translation>Tema aleatório</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1591"/>
+        <location filename="mainwindow.cpp" line="1614"/>
         <source>Failed to open %1 in the file manager.</source>
         <translation>Falha ao abrir %1 no gerenciador de arquivos.</translation>
     </message>
@@ -696,22 +696,32 @@ Reinstale a GUI (no SteamOS, execute novamente o install-GUI.sh) para instalá-l
 <context>
     <name>PreviewDialog</name>
     <message>
-        <location filename="previewdialog.cpp" line="34"/>
+        <location filename="previewdialog.cpp" line="62"/>
         <source>No boot options selected.</source>
         <translation>Nenhuma opção de inicialização selecionada.</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="89"/>
+        <location filename="previewdialog.cpp" line="166"/>
         <source>Preview</source>
         <translation>Pré-visualizar</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="101"/>
+        <location filename="previewdialog.cpp" line="181"/>
         <source>Approximate preview — rEFInd&apos;s real rendering also depends on the firmware resolution and theme.</source>
         <translation>Pré-visualização aproximada — a renderização real do rEFInd também depende da resolução do firmware e do tema.</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="107"/>
+        <location filename="previewdialog.cpp" line="184"/>
+        <source>Approximate preview showing the randomly picked &quot;%1&quot; theme — Random picks a theme anew each time the config is created.</source>
+        <translation>Pré-visualização aproximada mostrando o tema &quot;%1&quot; escolhido aleatoriamente — &quot;Aleatório&quot; escolhe um novo tema sempre que a configuração é criada.</translation>
+    </message>
+    <message>
+        <location filename="previewdialog.cpp" line="188"/>
+        <source>Approximate preview with the &quot;%1&quot; theme applied — rEFInd&apos;s real rendering also depends on the firmware resolution and the theme&apos;s other settings.</source>
+        <translation>Pré-visualização aproximada com o tema &quot;%1&quot; aplicado — a renderização real do rEFInd também depende da resolução do firmware e das outras definições do tema.</translation>
+    </message>
+    <message>
+        <location filename="previewdialog.cpp" line="197"/>
         <source>Boot screen</source>
         <translation>Tela de inicialização</translation>
     </message>

--- a/GUI/src/SteamDeck_rEFInd_ru.ts
+++ b/GUI/src/SteamDeck_rEFInd_ru.ts
@@ -120,7 +120,7 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="468"/>
-        <location filename="mainwindow.cpp" line="1590"/>
+        <location filename="mainwindow.cpp" line="1613"/>
         <source>Open Folder</source>
         <translation>Открыть папку</translation>
     </message>
@@ -280,9 +280,9 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="965"/>
-        <location filename="mainwindow.cpp" line="1545"/>
-        <location filename="mainwindow.cpp" line="1560"/>
-        <location filename="mainwindow.cpp" line="1565"/>
+        <location filename="mainwindow.cpp" line="1568"/>
+        <location filename="mainwindow.cpp" line="1583"/>
+        <location filename="mainwindow.cpp" line="1588"/>
         <source>Install Themes</source>
         <translation>Установить темы</translation>
     </message>
@@ -325,10 +325,10 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="1080"/>
-        <location filename="mainwindow.cpp" line="1086"/>
-        <location filename="mainwindow.cpp" line="1104"/>
-        <location filename="mainwindow.cpp" line="1110"/>
-        <location filename="mainwindow.cpp" line="1115"/>
+        <location filename="mainwindow.cpp" line="1109"/>
+        <location filename="mainwindow.cpp" line="1127"/>
+        <location filename="mainwindow.cpp" line="1133"/>
+        <location filename="mainwindow.cpp" line="1138"/>
         <source>Install Config</source>
         <translation>Установить конфиг</translation>
     </message>
@@ -491,7 +491,7 @@
         <translation>Не удалось полностью записать %1 — возможно, диск заполнен. Конфигурация не была обновлена.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1087"/>
+        <location filename="mainwindow.cpp" line="1110"/>
         <source>The config-install script was NOT run:
 
 %1
@@ -508,18 +508,18 @@ Reinstall the GUI to restore the original script, then try again.</source>
 Переустановите GUI, чтобы восстановить оригинальный скрипт, и попробуйте снова.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1105"/>
-        <location filename="mainwindow.cpp" line="1117"/>
+        <location filename="mainwindow.cpp" line="1128"/>
+        <location filename="mainwindow.cpp" line="1140"/>
         <source>Installing the config failed (code %1).</source>
         <translation>Не удалось установить конфигурацию (код %1).</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1112"/>
+        <location filename="mainwindow.cpp" line="1135"/>
         <source>The config was installed successfully.</source>
         <translation>Конфигурация успешно установлена.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1113"/>
+        <location filename="mainwindow.cpp" line="1136"/>
         <source>The config was installed successfully.
 
 %1</source>
@@ -528,7 +528,7 @@ Reinstall the GUI to restore the original script, then try again.</source>
 %1</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1118"/>
+        <location filename="mainwindow.cpp" line="1141"/>
         <source>Installing the config failed (code %1).
 
 %2</source>
@@ -537,28 +537,28 @@ Reinstall the GUI to restore the original script, then try again.</source>
 %2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1138"/>
-        <location filename="mainwindow.cpp" line="1148"/>
-        <location filename="mainwindow.cpp" line="1155"/>
+        <location filename="mainwindow.cpp" line="1161"/>
+        <location filename="mainwindow.cpp" line="1171"/>
+        <location filename="mainwindow.cpp" line="1178"/>
         <source>Copy PNG</source>
         <translation>Копировать PNG</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="935"/>
         <location filename="mainwindow.cpp" line="944"/>
-        <location filename="mainwindow.cpp" line="1139"/>
-        <location filename="mainwindow.cpp" line="1149"/>
-        <location filename="mainwindow.cpp" line="1156"/>
+        <location filename="mainwindow.cpp" line="1162"/>
+        <location filename="mainwindow.cpp" line="1172"/>
+        <location filename="mainwindow.cpp" line="1179"/>
         <source>Could not copy %1 to %2</source>
         <translation>Не удалось скопировать %1 в %2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1181"/>
+        <location filename="mainwindow.cpp" line="1204"/>
         <source>Invalid PNG</source>
         <translation>Недопустимый PNG</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1182"/>
+        <location filename="mainwindow.cpp" line="1205"/>
         <source>%1 is not a valid PNG file.
 
 Backgrounds and OS icons must be real PNG images (not just files with a .png extension).</source>
@@ -567,58 +567,58 @@ Backgrounds and OS icons must be real PNG images (not just files with a .png ext
 Фоны и значки ОС должны быть настоящими изображениями PNG (а не просто файлами с расширением .png).</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1445"/>
+        <location filename="mainwindow.cpp" line="1468"/>
         <source>Check For Update</source>
         <translation>Проверить обновления</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1448"/>
+        <location filename="mainwindow.cpp" line="1471"/>
         <source>&lt;p align=&apos;center&apos;&gt;&lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd&apos;&gt;rEFInd Customization GUI v%1&lt;/a&gt;&lt;br&gt;&lt;br&gt;Original GUI Creator: &lt;a href=&apos;https://github.com/jlobue10&apos;&gt;jlobue10&lt;/a&gt;&lt;br&gt;&lt;br&gt;Special Thanks to Deck Wizard for testing and QA&lt;br&gt;&lt;br&gt;&lt;a href=&apos;https://www.youtube.com/watch?v=yBHzVSDVEqw&apos;&gt;Deck Wizard Dual Boot Tutorial&lt;/a&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;&lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd&apos;&gt;rEFInd Customization GUI v%1&lt;/a&gt;&lt;br&gt;&lt;br&gt;Автор оригинального GUI: &lt;a href=&apos;https://github.com/jlobue10&apos;&gt;jlobue10&lt;/a&gt;&lt;br&gt;&lt;br&gt;Особая благодарность Deck Wizard за тестирование и контроль качества&lt;br&gt;&lt;br&gt;&lt;a href=&apos;https://www.youtube.com/watch?v=yBHzVSDVEqw&apos;&gt;Руководство Deck Wizard по двойной загрузке&lt;/a&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1497"/>
+        <location filename="mainwindow.cpp" line="1520"/>
         <source>&lt;p align=&apos;center&apos;&gt;Update check failed. Please check your internet connection and try again.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;Не удалось проверить обновления. Проверьте подключение к интернету и попробуйте снова.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1500"/>
+        <location filename="mainwindow.cpp" line="1523"/>
         <source>&lt;p align=&apos;center&apos;&gt;An update is available &lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd/releases&apos;&gt;here&lt;/a&gt;&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;Доступно обновление — &lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd/releases&apos;&gt;здесь&lt;/a&gt;&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1504"/>
+        <location filename="mainwindow.cpp" line="1527"/>
         <source>&lt;p align=&apos;center&apos;&gt;No update found. You are using the latest version.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;Обновлений не найдено. Вы используете последнюю версию.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1514"/>
-        <location filename="mainwindow.cpp" line="1521"/>
+        <location filename="mainwindow.cpp" line="1537"/>
+        <location filename="mainwindow.cpp" line="1544"/>
         <source>systemd service</source>
         <translation>Служба systemd</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1515"/>
-        <location filename="mainwindow.cpp" line="1522"/>
+        <location filename="mainwindow.cpp" line="1538"/>
+        <location filename="mainwindow.cpp" line="1545"/>
         <source>Failed to launch the service toggle.</source>
         <translation>Не удалось запустить переключение службы.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1528"/>
-        <location filename="mainwindow.cpp" line="1535"/>
+        <location filename="mainwindow.cpp" line="1551"/>
+        <location filename="mainwindow.cpp" line="1558"/>
         <source>Background Randomizer</source>
         <translation>Случайный фон</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1529"/>
-        <location filename="mainwindow.cpp" line="1536"/>
-        <location filename="mainwindow.cpp" line="1577"/>
-        <location filename="mainwindow.cpp" line="1584"/>
+        <location filename="mainwindow.cpp" line="1552"/>
+        <location filename="mainwindow.cpp" line="1559"/>
+        <location filename="mainwindow.cpp" line="1600"/>
+        <location filename="mainwindow.cpp" line="1607"/>
         <source>Failed to launch the randomizer setup.</source>
         <translation>Не удалось запустить настройку случайного фона.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1546"/>
+        <location filename="mainwindow.cpp" line="1569"/>
         <source>The themes-install script was NOT run:
 
 %1
@@ -635,12 +635,12 @@ Reinstall the GUI (on SteamOS, re-run install-GUI.sh) to install or restore it, 
 Переустановите GUI (в SteamOS повторно запустите install-GUI.sh), чтобы установить или восстановить его, и попробуйте снова.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1562"/>
+        <location filename="mainwindow.cpp" line="1585"/>
         <source>The themes were installed successfully.</source>
         <translation>Темы успешно установлены.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1563"/>
+        <location filename="mainwindow.cpp" line="1586"/>
         <source>The themes were installed successfully.
 
 %1</source>
@@ -649,12 +649,12 @@ Reinstall the GUI (on SteamOS, re-run install-GUI.sh) to install or restore it, 
 %1</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1567"/>
+        <location filename="mainwindow.cpp" line="1590"/>
         <source>Installing the themes failed (code %1).</source>
         <translation>Не удалось установить темы (код %1).</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1568"/>
+        <location filename="mainwindow.cpp" line="1591"/>
         <source>Installing the themes failed (code %1).
 
 %2</source>
@@ -663,13 +663,13 @@ Reinstall the GUI (on SteamOS, re-run install-GUI.sh) to install or restore it, 
 %2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1576"/>
-        <location filename="mainwindow.cpp" line="1583"/>
+        <location filename="mainwindow.cpp" line="1599"/>
+        <location filename="mainwindow.cpp" line="1606"/>
         <source>Theme Randomizer</source>
         <translation>Случайная тема</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1591"/>
+        <location filename="mainwindow.cpp" line="1614"/>
         <source>Failed to open %1 in the file manager.</source>
         <translation>Не удалось открыть %1 в файловом менеджере.</translation>
     </message>
@@ -696,22 +696,32 @@ Reinstall the GUI (on SteamOS, re-run install-GUI.sh) to install or restore it, 
 <context>
     <name>PreviewDialog</name>
     <message>
-        <location filename="previewdialog.cpp" line="34"/>
+        <location filename="previewdialog.cpp" line="62"/>
         <source>No boot options selected.</source>
         <translation>Варианты загрузки не выбраны.</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="89"/>
+        <location filename="previewdialog.cpp" line="166"/>
         <source>Preview</source>
         <translation>Предпросмотр</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="101"/>
+        <location filename="previewdialog.cpp" line="181"/>
         <source>Approximate preview — rEFInd&apos;s real rendering also depends on the firmware resolution and theme.</source>
         <translation>Примерный предпросмотр — реальное отображение rEFInd зависит также от разрешения прошивки и темы.</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="107"/>
+        <location filename="previewdialog.cpp" line="184"/>
+        <source>Approximate preview showing the randomly picked &quot;%1&quot; theme — Random picks a theme anew each time the config is created.</source>
+        <translation>Примерный предпросмотр со случайно выбранной темой «%1» — «Случайная» выбирает новую тему при каждом создании конфигурации.</translation>
+    </message>
+    <message>
+        <location filename="previewdialog.cpp" line="188"/>
+        <source>Approximate preview with the &quot;%1&quot; theme applied — rEFInd&apos;s real rendering also depends on the firmware resolution and the theme&apos;s other settings.</source>
+        <translation>Примерный предпросмотр с применённой темой «%1» — реальное отображение rEFInd зависит также от разрешения прошивки и остальных настроек темы.</translation>
+    </message>
+    <message>
+        <location filename="previewdialog.cpp" line="197"/>
         <source>Boot screen</source>
         <translation>Экран загрузки</translation>
     </message>

--- a/GUI/src/SteamDeck_rEFInd_scn.ts
+++ b/GUI/src/SteamDeck_rEFInd_scn.ts
@@ -699,6 +699,16 @@ Torna a nstallari la GUI (nta SteamOS, torna a esiquiri install-GUI.sh) pi lu ns
         <source>Boot screen</source>
         <translation>Schirmata d'avviu</translation>
     </message>
+    <message>
+        <location filename="previewdialog.cpp" line="184" />
+        <source>Approximate preview showing the randomly picked &quot;%1&quot; theme — Random picks a theme anew each time the config is created.</source>
+        <translation>Antiprima apprussimativa chi mustra lu tema &quot;%1&quot; scigghiutu a casu — &quot;Casuali&quot; scegghi un tema novu ogni vota ca si crea la cunfigurazzioni.</translation>
+    </message>
+    <message>
+        <location filename="previewdialog.cpp" line="188" />
+        <source>Approximate preview with the &quot;%1&quot; theme applied — rEFInd&apos;s real rendering also depends on the firmware resolution and the theme&apos;s other settings.</source>
+        <translation>Antiprima apprussimativa cu lu tema &quot;%1&quot; applicatu — comu rEFInd si vidi pi daveru dipenni puru di la risuluzzioni di lu firmware e di l&apos;àutri mpustazzioni di lu tema.</translation>
+    </message>
 </context>
 <context>
     <name>QGuiApplication</name>

--- a/GUI/src/SteamDeck_rEFInd_tr.ts
+++ b/GUI/src/SteamDeck_rEFInd_tr.ts
@@ -120,7 +120,7 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="468"/>
-        <location filename="mainwindow.cpp" line="1590"/>
+        <location filename="mainwindow.cpp" line="1613"/>
         <source>Open Folder</source>
         <translation>Klasörü aç</translation>
     </message>
@@ -280,9 +280,9 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="965"/>
-        <location filename="mainwindow.cpp" line="1545"/>
-        <location filename="mainwindow.cpp" line="1560"/>
-        <location filename="mainwindow.cpp" line="1565"/>
+        <location filename="mainwindow.cpp" line="1568"/>
+        <location filename="mainwindow.cpp" line="1583"/>
+        <location filename="mainwindow.cpp" line="1588"/>
         <source>Install Themes</source>
         <translation>Temaları kur</translation>
     </message>
@@ -325,10 +325,10 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="1080"/>
-        <location filename="mainwindow.cpp" line="1086"/>
-        <location filename="mainwindow.cpp" line="1104"/>
-        <location filename="mainwindow.cpp" line="1110"/>
-        <location filename="mainwindow.cpp" line="1115"/>
+        <location filename="mainwindow.cpp" line="1109"/>
+        <location filename="mainwindow.cpp" line="1127"/>
+        <location filename="mainwindow.cpp" line="1133"/>
+        <location filename="mainwindow.cpp" line="1138"/>
         <source>Install Config</source>
         <translation>Yapılandırmayı kur</translation>
     </message>
@@ -491,7 +491,7 @@
         <translation>%1 tamamen yazılamadı — disk dolu olabilir. Yapılandırma güncellenmedi.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1087"/>
+        <location filename="mainwindow.cpp" line="1110"/>
         <source>The config-install script was NOT run:
 
 %1
@@ -508,18 +508,18 @@ Uygulamanın bu sürümüyle birlikte gelen kopyayla eşleşmiyor. Betik root ye
 Özgün betiği geri yüklemek için GUI&apos;yi yeniden kurun ve tekrar deneyin.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1105"/>
-        <location filename="mainwindow.cpp" line="1117"/>
+        <location filename="mainwindow.cpp" line="1128"/>
+        <location filename="mainwindow.cpp" line="1140"/>
         <source>Installing the config failed (code %1).</source>
         <translation>Yapılandırma kurulumu başarısız oldu (kod %1).</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1112"/>
+        <location filename="mainwindow.cpp" line="1135"/>
         <source>The config was installed successfully.</source>
         <translation>Yapılandırma başarıyla kuruldu.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1113"/>
+        <location filename="mainwindow.cpp" line="1136"/>
         <source>The config was installed successfully.
 
 %1</source>
@@ -528,7 +528,7 @@ Uygulamanın bu sürümüyle birlikte gelen kopyayla eşleşmiyor. Betik root ye
 %1</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1118"/>
+        <location filename="mainwindow.cpp" line="1141"/>
         <source>Installing the config failed (code %1).
 
 %2</source>
@@ -537,28 +537,28 @@ Uygulamanın bu sürümüyle birlikte gelen kopyayla eşleşmiyor. Betik root ye
 %2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1138"/>
-        <location filename="mainwindow.cpp" line="1148"/>
-        <location filename="mainwindow.cpp" line="1155"/>
+        <location filename="mainwindow.cpp" line="1161"/>
+        <location filename="mainwindow.cpp" line="1171"/>
+        <location filename="mainwindow.cpp" line="1178"/>
         <source>Copy PNG</source>
         <translation>PNG kopyala</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="935"/>
         <location filename="mainwindow.cpp" line="944"/>
-        <location filename="mainwindow.cpp" line="1139"/>
-        <location filename="mainwindow.cpp" line="1149"/>
-        <location filename="mainwindow.cpp" line="1156"/>
+        <location filename="mainwindow.cpp" line="1162"/>
+        <location filename="mainwindow.cpp" line="1172"/>
+        <location filename="mainwindow.cpp" line="1179"/>
         <source>Could not copy %1 to %2</source>
         <translation>%1, %2 konumuna kopyalanamadı</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1181"/>
+        <location filename="mainwindow.cpp" line="1204"/>
         <source>Invalid PNG</source>
         <translation>Geçersiz PNG</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1182"/>
+        <location filename="mainwindow.cpp" line="1205"/>
         <source>%1 is not a valid PNG file.
 
 Backgrounds and OS icons must be real PNG images (not just files with a .png extension).</source>
@@ -567,58 +567,58 @@ Backgrounds and OS icons must be real PNG images (not just files with a .png ext
 Arka planlar ve işletim sistemi simgeleri gerçek PNG görüntüleri olmalıdır (yalnızca .png uzantılı dosyalar değil).</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1445"/>
+        <location filename="mainwindow.cpp" line="1468"/>
         <source>Check For Update</source>
         <translation>Güncellemeleri denetle</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1448"/>
+        <location filename="mainwindow.cpp" line="1471"/>
         <source>&lt;p align=&apos;center&apos;&gt;&lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd&apos;&gt;rEFInd Customization GUI v%1&lt;/a&gt;&lt;br&gt;&lt;br&gt;Original GUI Creator: &lt;a href=&apos;https://github.com/jlobue10&apos;&gt;jlobue10&lt;/a&gt;&lt;br&gt;&lt;br&gt;Special Thanks to Deck Wizard for testing and QA&lt;br&gt;&lt;br&gt;&lt;a href=&apos;https://www.youtube.com/watch?v=yBHzVSDVEqw&apos;&gt;Deck Wizard Dual Boot Tutorial&lt;/a&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;&lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd&apos;&gt;rEFInd Customization GUI v%1&lt;/a&gt;&lt;br&gt;&lt;br&gt;Özgün GUI geliştiricisi: &lt;a href=&apos;https://github.com/jlobue10&apos;&gt;jlobue10&lt;/a&gt;&lt;br&gt;&lt;br&gt;Test ve kalite güvencesi için Deck Wizard&apos;a özel teşekkürler&lt;br&gt;&lt;br&gt;&lt;a href=&apos;https://www.youtube.com/watch?v=yBHzVSDVEqw&apos;&gt;Deck Wizard çift önyükleme rehberi&lt;/a&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1497"/>
+        <location filename="mainwindow.cpp" line="1520"/>
         <source>&lt;p align=&apos;center&apos;&gt;Update check failed. Please check your internet connection and try again.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;Güncelleme denetimi başarısız oldu. İnternet bağlantınızı denetleyip yeniden deneyin.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1500"/>
+        <location filename="mainwindow.cpp" line="1523"/>
         <source>&lt;p align=&apos;center&apos;&gt;An update is available &lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd/releases&apos;&gt;here&lt;/a&gt;&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;Bir güncelleme &lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd/releases&apos;&gt;burada&lt;/a&gt; mevcut&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1504"/>
+        <location filename="mainwindow.cpp" line="1527"/>
         <source>&lt;p align=&apos;center&apos;&gt;No update found. You are using the latest version.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;Güncelleme bulunamadı. En son sürümü kullanıyorsunuz.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1514"/>
-        <location filename="mainwindow.cpp" line="1521"/>
+        <location filename="mainwindow.cpp" line="1537"/>
+        <location filename="mainwindow.cpp" line="1544"/>
         <source>systemd service</source>
         <translation>systemd hizmeti</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1515"/>
-        <location filename="mainwindow.cpp" line="1522"/>
+        <location filename="mainwindow.cpp" line="1538"/>
+        <location filename="mainwindow.cpp" line="1545"/>
         <source>Failed to launch the service toggle.</source>
         <translation>Hizmet geçişi başlatılamadı.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1528"/>
-        <location filename="mainwindow.cpp" line="1535"/>
+        <location filename="mainwindow.cpp" line="1551"/>
+        <location filename="mainwindow.cpp" line="1558"/>
         <source>Background Randomizer</source>
         <translation>Rastgele arka plan</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1529"/>
-        <location filename="mainwindow.cpp" line="1536"/>
-        <location filename="mainwindow.cpp" line="1577"/>
-        <location filename="mainwindow.cpp" line="1584"/>
+        <location filename="mainwindow.cpp" line="1552"/>
+        <location filename="mainwindow.cpp" line="1559"/>
+        <location filename="mainwindow.cpp" line="1600"/>
+        <location filename="mainwindow.cpp" line="1607"/>
         <source>Failed to launch the randomizer setup.</source>
         <translation>Rastgele arka plan ayarı başlatılamadı.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1546"/>
+        <location filename="mainwindow.cpp" line="1569"/>
         <source>The themes-install script was NOT run:
 
 %1
@@ -635,12 +635,12 @@ Betik eksik veya uygulamanın bu sürümüyle birlikte gelen kopyayla eşleşmiy
 Betiği kurmak veya geri yüklemek için GUI&apos;yi yeniden kurun (SteamOS&apos;ta install-GUI.sh betiğini yeniden çalıştırın) ve tekrar deneyin.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1562"/>
+        <location filename="mainwindow.cpp" line="1585"/>
         <source>The themes were installed successfully.</source>
         <translation>Temalar başarıyla kuruldu.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1563"/>
+        <location filename="mainwindow.cpp" line="1586"/>
         <source>The themes were installed successfully.
 
 %1</source>
@@ -649,12 +649,12 @@ Betiği kurmak veya geri yüklemek için GUI&apos;yi yeniden kurun (SteamOS&apos
 %1</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1567"/>
+        <location filename="mainwindow.cpp" line="1590"/>
         <source>Installing the themes failed (code %1).</source>
         <translation>Temaların kurulumu başarısız oldu (kod %1).</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1568"/>
+        <location filename="mainwindow.cpp" line="1591"/>
         <source>Installing the themes failed (code %1).
 
 %2</source>
@@ -663,13 +663,13 @@ Betiği kurmak veya geri yüklemek için GUI&apos;yi yeniden kurun (SteamOS&apos
 %2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1576"/>
-        <location filename="mainwindow.cpp" line="1583"/>
+        <location filename="mainwindow.cpp" line="1599"/>
+        <location filename="mainwindow.cpp" line="1606"/>
         <source>Theme Randomizer</source>
         <translation>Rastgele tema</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1591"/>
+        <location filename="mainwindow.cpp" line="1614"/>
         <source>Failed to open %1 in the file manager.</source>
         <translation>%1 dosya yöneticisinde açılamadı.</translation>
     </message>
@@ -696,22 +696,32 @@ Betiği kurmak veya geri yüklemek için GUI&apos;yi yeniden kurun (SteamOS&apos
 <context>
     <name>PreviewDialog</name>
     <message>
-        <location filename="previewdialog.cpp" line="34"/>
+        <location filename="previewdialog.cpp" line="62"/>
         <source>No boot options selected.</source>
         <translation>Önyükleme seçeneği seçilmedi.</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="89"/>
+        <location filename="previewdialog.cpp" line="166"/>
         <source>Preview</source>
         <translation>Önizleme</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="101"/>
+        <location filename="previewdialog.cpp" line="181"/>
         <source>Approximate preview — rEFInd&apos;s real rendering also depends on the firmware resolution and theme.</source>
         <translation>Yaklaşık önizleme — rEFInd&apos;in gerçek görünümü ürün yazılımı çözünürlüğüne ve temaya da bağlıdır.</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="107"/>
+        <location filename="previewdialog.cpp" line="184"/>
+        <source>Approximate preview showing the randomly picked &quot;%1&quot; theme — Random picks a theme anew each time the config is created.</source>
+        <translation>Rastgele seçilen &quot;%1&quot; temasıyla yaklaşık önizleme — &quot;Rastgele&quot;, yapılandırma her oluşturulduğunda yeni bir tema seçer.</translation>
+    </message>
+    <message>
+        <location filename="previewdialog.cpp" line="188"/>
+        <source>Approximate preview with the &quot;%1&quot; theme applied — rEFInd&apos;s real rendering also depends on the firmware resolution and the theme&apos;s other settings.</source>
+        <translation>&quot;%1&quot; teması uygulanmış yaklaşık önizleme — rEFInd&apos;in gerçek görünümü ürün yazılımı çözünürlüğüne ve temanın diğer ayarlarına da bağlıdır.</translation>
+    </message>
+    <message>
+        <location filename="previewdialog.cpp" line="197"/>
         <source>Boot screen</source>
         <translation>Önyükleme ekranı</translation>
     </message>

--- a/GUI/src/SteamDeck_rEFInd_uk.ts
+++ b/GUI/src/SteamDeck_rEFInd_uk.ts
@@ -120,7 +120,7 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="468"/>
-        <location filename="mainwindow.cpp" line="1590"/>
+        <location filename="mainwindow.cpp" line="1613"/>
         <source>Open Folder</source>
         <translation>Відкрити теку</translation>
     </message>
@@ -280,9 +280,9 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="965"/>
-        <location filename="mainwindow.cpp" line="1545"/>
-        <location filename="mainwindow.cpp" line="1560"/>
-        <location filename="mainwindow.cpp" line="1565"/>
+        <location filename="mainwindow.cpp" line="1568"/>
+        <location filename="mainwindow.cpp" line="1583"/>
+        <location filename="mainwindow.cpp" line="1588"/>
         <source>Install Themes</source>
         <translation>Встановити теми</translation>
     </message>
@@ -325,10 +325,10 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="1080"/>
-        <location filename="mainwindow.cpp" line="1086"/>
-        <location filename="mainwindow.cpp" line="1104"/>
-        <location filename="mainwindow.cpp" line="1110"/>
-        <location filename="mainwindow.cpp" line="1115"/>
+        <location filename="mainwindow.cpp" line="1109"/>
+        <location filename="mainwindow.cpp" line="1127"/>
+        <location filename="mainwindow.cpp" line="1133"/>
+        <location filename="mainwindow.cpp" line="1138"/>
         <source>Install Config</source>
         <translation>Встановити конфіг</translation>
     </message>
@@ -491,7 +491,7 @@
         <translation>Не вдалося повністю записати %1 — можливо, диск переповнений. Конфігурацію не було оновлено.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1087"/>
+        <location filename="mainwindow.cpp" line="1110"/>
         <source>The config-install script was NOT run:
 
 %1
@@ -508,18 +508,18 @@ Reinstall the GUI to restore the original script, then try again.</source>
 Перевстановіть GUI, щоб відновити оригінальний скрипт, і спробуйте ще раз.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1105"/>
-        <location filename="mainwindow.cpp" line="1117"/>
+        <location filename="mainwindow.cpp" line="1128"/>
+        <location filename="mainwindow.cpp" line="1140"/>
         <source>Installing the config failed (code %1).</source>
         <translation>Не вдалося встановити конфігурацію (код %1).</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1112"/>
+        <location filename="mainwindow.cpp" line="1135"/>
         <source>The config was installed successfully.</source>
         <translation>Конфігурацію успішно встановлено.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1113"/>
+        <location filename="mainwindow.cpp" line="1136"/>
         <source>The config was installed successfully.
 
 %1</source>
@@ -528,7 +528,7 @@ Reinstall the GUI to restore the original script, then try again.</source>
 %1</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1118"/>
+        <location filename="mainwindow.cpp" line="1141"/>
         <source>Installing the config failed (code %1).
 
 %2</source>
@@ -537,28 +537,28 @@ Reinstall the GUI to restore the original script, then try again.</source>
 %2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1138"/>
-        <location filename="mainwindow.cpp" line="1148"/>
-        <location filename="mainwindow.cpp" line="1155"/>
+        <location filename="mainwindow.cpp" line="1161"/>
+        <location filename="mainwindow.cpp" line="1171"/>
+        <location filename="mainwindow.cpp" line="1178"/>
         <source>Copy PNG</source>
         <translation>Копіювати PNG</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="935"/>
         <location filename="mainwindow.cpp" line="944"/>
-        <location filename="mainwindow.cpp" line="1139"/>
-        <location filename="mainwindow.cpp" line="1149"/>
-        <location filename="mainwindow.cpp" line="1156"/>
+        <location filename="mainwindow.cpp" line="1162"/>
+        <location filename="mainwindow.cpp" line="1172"/>
+        <location filename="mainwindow.cpp" line="1179"/>
         <source>Could not copy %1 to %2</source>
         <translation>Не вдалося скопіювати %1 до %2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1181"/>
+        <location filename="mainwindow.cpp" line="1204"/>
         <source>Invalid PNG</source>
         <translation>Недійсний PNG</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1182"/>
+        <location filename="mainwindow.cpp" line="1205"/>
         <source>%1 is not a valid PNG file.
 
 Backgrounds and OS icons must be real PNG images (not just files with a .png extension).</source>
@@ -567,58 +567,58 @@ Backgrounds and OS icons must be real PNG images (not just files with a .png ext
 Фони та значки ОС мають бути справжніми зображеннями PNG (а не просто файлами з розширенням .png).</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1445"/>
+        <location filename="mainwindow.cpp" line="1468"/>
         <source>Check For Update</source>
         <translation>Перевірити оновлення</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1448"/>
+        <location filename="mainwindow.cpp" line="1471"/>
         <source>&lt;p align=&apos;center&apos;&gt;&lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd&apos;&gt;rEFInd Customization GUI v%1&lt;/a&gt;&lt;br&gt;&lt;br&gt;Original GUI Creator: &lt;a href=&apos;https://github.com/jlobue10&apos;&gt;jlobue10&lt;/a&gt;&lt;br&gt;&lt;br&gt;Special Thanks to Deck Wizard for testing and QA&lt;br&gt;&lt;br&gt;&lt;a href=&apos;https://www.youtube.com/watch?v=yBHzVSDVEqw&apos;&gt;Deck Wizard Dual Boot Tutorial&lt;/a&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;&lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd&apos;&gt;rEFInd Customization GUI v%1&lt;/a&gt;&lt;br&gt;&lt;br&gt;Автор оригінального GUI: &lt;a href=&apos;https://github.com/jlobue10&apos;&gt;jlobue10&lt;/a&gt;&lt;br&gt;&lt;br&gt;Особлива подяка Deck Wizard за тестування та контроль якості&lt;br&gt;&lt;br&gt;&lt;a href=&apos;https://www.youtube.com/watch?v=yBHzVSDVEqw&apos;&gt;Посібник Deck Wizard із подвійного завантаження&lt;/a&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1497"/>
+        <location filename="mainwindow.cpp" line="1520"/>
         <source>&lt;p align=&apos;center&apos;&gt;Update check failed. Please check your internet connection and try again.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;Не вдалося перевірити оновлення. Перевірте з&apos;єднання з інтернетом і спробуйте ще раз.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1500"/>
+        <location filename="mainwindow.cpp" line="1523"/>
         <source>&lt;p align=&apos;center&apos;&gt;An update is available &lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd/releases&apos;&gt;here&lt;/a&gt;&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;Доступне оновлення — &lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd/releases&apos;&gt;тут&lt;/a&gt;&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1504"/>
+        <location filename="mainwindow.cpp" line="1527"/>
         <source>&lt;p align=&apos;center&apos;&gt;No update found. You are using the latest version.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;Оновлень не знайдено. Ви користуєтеся найновішою версією.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1514"/>
-        <location filename="mainwindow.cpp" line="1521"/>
+        <location filename="mainwindow.cpp" line="1537"/>
+        <location filename="mainwindow.cpp" line="1544"/>
         <source>systemd service</source>
         <translation>Служба systemd</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1515"/>
-        <location filename="mainwindow.cpp" line="1522"/>
+        <location filename="mainwindow.cpp" line="1538"/>
+        <location filename="mainwindow.cpp" line="1545"/>
         <source>Failed to launch the service toggle.</source>
         <translation>Не вдалося запустити перемикання служби.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1528"/>
-        <location filename="mainwindow.cpp" line="1535"/>
+        <location filename="mainwindow.cpp" line="1551"/>
+        <location filename="mainwindow.cpp" line="1558"/>
         <source>Background Randomizer</source>
         <translation>Випадковий фон</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1529"/>
-        <location filename="mainwindow.cpp" line="1536"/>
-        <location filename="mainwindow.cpp" line="1577"/>
-        <location filename="mainwindow.cpp" line="1584"/>
+        <location filename="mainwindow.cpp" line="1552"/>
+        <location filename="mainwindow.cpp" line="1559"/>
+        <location filename="mainwindow.cpp" line="1600"/>
+        <location filename="mainwindow.cpp" line="1607"/>
         <source>Failed to launch the randomizer setup.</source>
         <translation>Не вдалося запустити налаштування випадкового фону.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1546"/>
+        <location filename="mainwindow.cpp" line="1569"/>
         <source>The themes-install script was NOT run:
 
 %1
@@ -635,12 +635,12 @@ Reinstall the GUI (on SteamOS, re-run install-GUI.sh) to install or restore it, 
 Перевстановіть GUI (у SteamOS повторно запустіть install-GUI.sh), щоб установити або відновити його, і спробуйте ще раз.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1562"/>
+        <location filename="mainwindow.cpp" line="1585"/>
         <source>The themes were installed successfully.</source>
         <translation>Теми успішно встановлено.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1563"/>
+        <location filename="mainwindow.cpp" line="1586"/>
         <source>The themes were installed successfully.
 
 %1</source>
@@ -649,12 +649,12 @@ Reinstall the GUI (on SteamOS, re-run install-GUI.sh) to install or restore it, 
 %1</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1567"/>
+        <location filename="mainwindow.cpp" line="1590"/>
         <source>Installing the themes failed (code %1).</source>
         <translation>Не вдалося встановити теми (код %1).</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1568"/>
+        <location filename="mainwindow.cpp" line="1591"/>
         <source>Installing the themes failed (code %1).
 
 %2</source>
@@ -663,13 +663,13 @@ Reinstall the GUI (on SteamOS, re-run install-GUI.sh) to install or restore it, 
 %2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1576"/>
-        <location filename="mainwindow.cpp" line="1583"/>
+        <location filename="mainwindow.cpp" line="1599"/>
+        <location filename="mainwindow.cpp" line="1606"/>
         <source>Theme Randomizer</source>
         <translation>Випадкова тема</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1591"/>
+        <location filename="mainwindow.cpp" line="1614"/>
         <source>Failed to open %1 in the file manager.</source>
         <translation>Не вдалося відкрити %1 у файловому менеджері.</translation>
     </message>
@@ -696,22 +696,32 @@ Reinstall the GUI (on SteamOS, re-run install-GUI.sh) to install or restore it, 
 <context>
     <name>PreviewDialog</name>
     <message>
-        <location filename="previewdialog.cpp" line="34"/>
+        <location filename="previewdialog.cpp" line="62"/>
         <source>No boot options selected.</source>
         <translation>Варіанти завантаження не вибрано.</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="89"/>
+        <location filename="previewdialog.cpp" line="166"/>
         <source>Preview</source>
         <translation>Перегляд</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="101"/>
+        <location filename="previewdialog.cpp" line="181"/>
         <source>Approximate preview — rEFInd&apos;s real rendering also depends on the firmware resolution and theme.</source>
         <translation>Приблизний попередній перегляд — справжнє відображення rEFInd залежить також від роздільної здатності прошивки й теми.</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="107"/>
+        <location filename="previewdialog.cpp" line="184"/>
+        <source>Approximate preview showing the randomly picked &quot;%1&quot; theme — Random picks a theme anew each time the config is created.</source>
+        <translation>Приблизний попередній перегляд із випадково вибраною темою «%1» — «Випадкова» вибирає нову тему щоразу під час створення конфігурації.</translation>
+    </message>
+    <message>
+        <location filename="previewdialog.cpp" line="188"/>
+        <source>Approximate preview with the &quot;%1&quot; theme applied — rEFInd&apos;s real rendering also depends on the firmware resolution and the theme&apos;s other settings.</source>
+        <translation>Приблизний попередній перегляд із застосованою темою «%1» — справжнє відображення rEFInd залежить також від роздільної здатності прошивки й інших налаштувань теми.</translation>
+    </message>
+    <message>
+        <location filename="previewdialog.cpp" line="197"/>
         <source>Boot screen</source>
         <translation>Екран завантаження</translation>
     </message>

--- a/GUI/src/SteamDeck_rEFInd_ur.ts
+++ b/GUI/src/SteamDeck_rEFInd_ur.ts
@@ -120,7 +120,7 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="468"/>
-        <location filename="mainwindow.cpp" line="1590"/>
+        <location filename="mainwindow.cpp" line="1613"/>
         <source>Open Folder</source>
         <translation>فولڈر کھولیں</translation>
     </message>
@@ -280,9 +280,9 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="965"/>
-        <location filename="mainwindow.cpp" line="1545"/>
-        <location filename="mainwindow.cpp" line="1560"/>
-        <location filename="mainwindow.cpp" line="1565"/>
+        <location filename="mainwindow.cpp" line="1568"/>
+        <location filename="mainwindow.cpp" line="1583"/>
+        <location filename="mainwindow.cpp" line="1588"/>
         <source>Install Themes</source>
         <translation>تھیمز انسٹال کریں</translation>
     </message>
@@ -325,10 +325,10 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="1080"/>
-        <location filename="mainwindow.cpp" line="1086"/>
-        <location filename="mainwindow.cpp" line="1104"/>
-        <location filename="mainwindow.cpp" line="1110"/>
-        <location filename="mainwindow.cpp" line="1115"/>
+        <location filename="mainwindow.cpp" line="1109"/>
+        <location filename="mainwindow.cpp" line="1127"/>
+        <location filename="mainwindow.cpp" line="1133"/>
+        <location filename="mainwindow.cpp" line="1138"/>
         <source>Install Config</source>
         <translation>کنفیگ انسٹال کریں</translation>
     </message>
@@ -491,7 +491,7 @@
         <translation>%1 مکمل طور پر نہیں لکھا جا سکا — ممکن ہے ڈسک بھری ہو۔ کنفیگریشن اپ ڈیٹ نہیں ہوئی۔</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1087"/>
+        <location filename="mainwindow.cpp" line="1110"/>
         <source>The config-install script was NOT run:
 
 %1
@@ -508,18 +508,18 @@ Reinstall the GUI to restore the original script, then try again.</source>
 اصل اسکرپٹ بحال کرنے کے لیے GUI دوبارہ انسٹال کریں، پھر دوبارہ کوشش کریں۔</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1105"/>
-        <location filename="mainwindow.cpp" line="1117"/>
+        <location filename="mainwindow.cpp" line="1128"/>
+        <location filename="mainwindow.cpp" line="1140"/>
         <source>Installing the config failed (code %1).</source>
         <translation>کنفیگریشن کی تنصیب ناکام رہی (کوڈ %1)۔</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1112"/>
+        <location filename="mainwindow.cpp" line="1135"/>
         <source>The config was installed successfully.</source>
         <translation>کنفیگریشن کامیابی سے انسٹال ہو گئی۔</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1113"/>
+        <location filename="mainwindow.cpp" line="1136"/>
         <source>The config was installed successfully.
 
 %1</source>
@@ -528,7 +528,7 @@ Reinstall the GUI to restore the original script, then try again.</source>
 %1</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1118"/>
+        <location filename="mainwindow.cpp" line="1141"/>
         <source>Installing the config failed (code %1).
 
 %2</source>
@@ -537,28 +537,28 @@ Reinstall the GUI to restore the original script, then try again.</source>
 %2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1138"/>
-        <location filename="mainwindow.cpp" line="1148"/>
-        <location filename="mainwindow.cpp" line="1155"/>
+        <location filename="mainwindow.cpp" line="1161"/>
+        <location filename="mainwindow.cpp" line="1171"/>
+        <location filename="mainwindow.cpp" line="1178"/>
         <source>Copy PNG</source>
         <translation>PNG کاپی کریں</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="935"/>
         <location filename="mainwindow.cpp" line="944"/>
-        <location filename="mainwindow.cpp" line="1139"/>
-        <location filename="mainwindow.cpp" line="1149"/>
-        <location filename="mainwindow.cpp" line="1156"/>
+        <location filename="mainwindow.cpp" line="1162"/>
+        <location filename="mainwindow.cpp" line="1172"/>
+        <location filename="mainwindow.cpp" line="1179"/>
         <source>Could not copy %1 to %2</source>
         <translation>%1 کو %2 میں کاپی نہیں کیا جا سکا</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1181"/>
+        <location filename="mainwindow.cpp" line="1204"/>
         <source>Invalid PNG</source>
         <translation>غلط PNG</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1182"/>
+        <location filename="mainwindow.cpp" line="1205"/>
         <source>%1 is not a valid PNG file.
 
 Backgrounds and OS icons must be real PNG images (not just files with a .png extension).</source>
@@ -567,58 +567,58 @@ Backgrounds and OS icons must be real PNG images (not just files with a .png ext
 پس منظر اور OS آئیکن اصل PNG تصاویر ہونی چاہئیں (صرف ‎.png ایکسٹینشن والی فائلیں نہیں)۔</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1445"/>
+        <location filename="mainwindow.cpp" line="1468"/>
         <source>Check For Update</source>
         <translation>اپ ڈیٹ چیک کریں</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1448"/>
+        <location filename="mainwindow.cpp" line="1471"/>
         <source>&lt;p align=&apos;center&apos;&gt;&lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd&apos;&gt;rEFInd Customization GUI v%1&lt;/a&gt;&lt;br&gt;&lt;br&gt;Original GUI Creator: &lt;a href=&apos;https://github.com/jlobue10&apos;&gt;jlobue10&lt;/a&gt;&lt;br&gt;&lt;br&gt;Special Thanks to Deck Wizard for testing and QA&lt;br&gt;&lt;br&gt;&lt;a href=&apos;https://www.youtube.com/watch?v=yBHzVSDVEqw&apos;&gt;Deck Wizard Dual Boot Tutorial&lt;/a&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;&lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd&apos;&gt;rEFInd Customization GUI v%1&lt;/a&gt;&lt;br&gt;&lt;br&gt;اصل GUI بنانے والا: &lt;a href=&apos;https://github.com/jlobue10&apos;&gt;jlobue10&lt;/a&gt;&lt;br&gt;&lt;br&gt;جانچ اور معیار کی یقین دہانی کے لیے Deck Wizard کا خصوصی شکریہ&lt;br&gt;&lt;br&gt;&lt;a href=&apos;https://www.youtube.com/watch?v=yBHzVSDVEqw&apos;&gt;Deck Wizard ڈوئل بوٹ ٹیوٹوریل&lt;/a&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1497"/>
+        <location filename="mainwindow.cpp" line="1520"/>
         <source>&lt;p align=&apos;center&apos;&gt;Update check failed. Please check your internet connection and try again.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;اپ ڈیٹ چیک ناکام رہا۔ براہ کرم اپنا انٹرنیٹ کنکشن چیک کریں اور دوبارہ کوشش کریں۔&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1500"/>
+        <location filename="mainwindow.cpp" line="1523"/>
         <source>&lt;p align=&apos;center&apos;&gt;An update is available &lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd/releases&apos;&gt;here&lt;/a&gt;&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;اپ ڈیٹ &lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd/releases&apos;&gt;یہاں&lt;/a&gt; دستیاب ہے&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1504"/>
+        <location filename="mainwindow.cpp" line="1527"/>
         <source>&lt;p align=&apos;center&apos;&gt;No update found. You are using the latest version.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;کوئی اپ ڈیٹ نہیں ملا۔ آپ تازہ ترین ورژن استعمال کر رہے ہیں۔&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1514"/>
-        <location filename="mainwindow.cpp" line="1521"/>
+        <location filename="mainwindow.cpp" line="1537"/>
+        <location filename="mainwindow.cpp" line="1544"/>
         <source>systemd service</source>
         <translation>systemd سروس</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1515"/>
-        <location filename="mainwindow.cpp" line="1522"/>
+        <location filename="mainwindow.cpp" line="1538"/>
+        <location filename="mainwindow.cpp" line="1545"/>
         <source>Failed to launch the service toggle.</source>
         <translation>سروس ٹوگل شروع نہیں ہو سکا۔</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1528"/>
-        <location filename="mainwindow.cpp" line="1535"/>
+        <location filename="mainwindow.cpp" line="1551"/>
+        <location filename="mainwindow.cpp" line="1558"/>
         <source>Background Randomizer</source>
         <translation>بے ترتیب پس منظر</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1529"/>
-        <location filename="mainwindow.cpp" line="1536"/>
-        <location filename="mainwindow.cpp" line="1577"/>
-        <location filename="mainwindow.cpp" line="1584"/>
+        <location filename="mainwindow.cpp" line="1552"/>
+        <location filename="mainwindow.cpp" line="1559"/>
+        <location filename="mainwindow.cpp" line="1600"/>
+        <location filename="mainwindow.cpp" line="1607"/>
         <source>Failed to launch the randomizer setup.</source>
         <translation>بے ترتیب پس منظر کا سیٹ اپ شروع نہیں ہو سکا۔</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1546"/>
+        <location filename="mainwindow.cpp" line="1569"/>
         <source>The themes-install script was NOT run:
 
 %1
@@ -635,12 +635,12 @@ Reinstall the GUI (on SteamOS, re-run install-GUI.sh) to install or restore it, 
 اسے انسٹال یا بحال کرنے کے لیے GUI دوبارہ انسٹال کریں (SteamOS پر install-GUI.sh دوبارہ چلائیں)، پھر دوبارہ کوشش کریں۔</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1562"/>
+        <location filename="mainwindow.cpp" line="1585"/>
         <source>The themes were installed successfully.</source>
         <translation>تھیمز کامیابی سے انسٹال ہو گئیں۔</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1563"/>
+        <location filename="mainwindow.cpp" line="1586"/>
         <source>The themes were installed successfully.
 
 %1</source>
@@ -649,12 +649,12 @@ Reinstall the GUI (on SteamOS, re-run install-GUI.sh) to install or restore it, 
 %1</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1567"/>
+        <location filename="mainwindow.cpp" line="1590"/>
         <source>Installing the themes failed (code %1).</source>
         <translation>تھیمز کی تنصیب ناکام رہی (کوڈ %1)۔</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1568"/>
+        <location filename="mainwindow.cpp" line="1591"/>
         <source>Installing the themes failed (code %1).
 
 %2</source>
@@ -663,13 +663,13 @@ Reinstall the GUI (on SteamOS, re-run install-GUI.sh) to install or restore it, 
 %2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1576"/>
-        <location filename="mainwindow.cpp" line="1583"/>
+        <location filename="mainwindow.cpp" line="1599"/>
+        <location filename="mainwindow.cpp" line="1606"/>
         <source>Theme Randomizer</source>
         <translation>بے ترتیب تھیم</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1591"/>
+        <location filename="mainwindow.cpp" line="1614"/>
         <source>Failed to open %1 in the file manager.</source>
         <translation>فائل مینیجر میں %1 کھولا نہیں جا سکا۔</translation>
     </message>
@@ -696,22 +696,32 @@ Reinstall the GUI (on SteamOS, re-run install-GUI.sh) to install or restore it, 
 <context>
     <name>PreviewDialog</name>
     <message>
-        <location filename="previewdialog.cpp" line="34"/>
+        <location filename="previewdialog.cpp" line="62"/>
         <source>No boot options selected.</source>
         <translation>کوئی بوٹ آپشن منتخب نہیں۔</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="89"/>
+        <location filename="previewdialog.cpp" line="166"/>
         <source>Preview</source>
         <translation>پیش منظر</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="101"/>
+        <location filename="previewdialog.cpp" line="181"/>
         <source>Approximate preview — rEFInd&apos;s real rendering also depends on the firmware resolution and theme.</source>
         <translation>تخمینی پیش منظر — rEFInd کا اصل ڈسپلے فرم ویئر ریزولوشن اور تھیم پر بھی منحصر ہے۔</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="107"/>
+        <location filename="previewdialog.cpp" line="184"/>
+        <source>Approximate preview showing the randomly picked &quot;%1&quot; theme — Random picks a theme anew each time the config is created.</source>
+        <translation>تخمینی پیش منظر جس میں بے ترتیب منتخب کردہ تھیم &quot;%1&quot; دکھایا گیا ہے — &quot;بے ترتیب&quot; ہر بار کنفیگریشن بننے پر نیا تھیم منتخب کرتا ہے۔</translation>
+    </message>
+    <message>
+        <location filename="previewdialog.cpp" line="188"/>
+        <source>Approximate preview with the &quot;%1&quot; theme applied — rEFInd&apos;s real rendering also depends on the firmware resolution and the theme&apos;s other settings.</source>
+        <translation>تھیم &quot;%1&quot; کے اطلاق کے ساتھ تخمینی پیش منظر — rEFInd کا اصل ڈسپلے فرم ویئر ریزولوشن اور تھیم کی دیگر ترتیبات پر بھی منحصر ہے۔</translation>
+    </message>
+    <message>
+        <location filename="previewdialog.cpp" line="197"/>
         <source>Boot screen</source>
         <translation>بوٹ اسکرین</translation>
     </message>

--- a/GUI/src/SteamDeck_rEFInd_vi.ts
+++ b/GUI/src/SteamDeck_rEFInd_vi.ts
@@ -120,7 +120,7 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="468"/>
-        <location filename="mainwindow.cpp" line="1590"/>
+        <location filename="mainwindow.cpp" line="1613"/>
         <source>Open Folder</source>
         <translation>Mở thư mục</translation>
     </message>
@@ -280,9 +280,9 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="965"/>
-        <location filename="mainwindow.cpp" line="1545"/>
-        <location filename="mainwindow.cpp" line="1560"/>
-        <location filename="mainwindow.cpp" line="1565"/>
+        <location filename="mainwindow.cpp" line="1568"/>
+        <location filename="mainwindow.cpp" line="1583"/>
+        <location filename="mainwindow.cpp" line="1588"/>
         <source>Install Themes</source>
         <translation>Cài chủ đề</translation>
     </message>
@@ -325,10 +325,10 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="1080"/>
-        <location filename="mainwindow.cpp" line="1086"/>
-        <location filename="mainwindow.cpp" line="1104"/>
-        <location filename="mainwindow.cpp" line="1110"/>
-        <location filename="mainwindow.cpp" line="1115"/>
+        <location filename="mainwindow.cpp" line="1109"/>
+        <location filename="mainwindow.cpp" line="1127"/>
+        <location filename="mainwindow.cpp" line="1133"/>
+        <location filename="mainwindow.cpp" line="1138"/>
         <source>Install Config</source>
         <translation>Cài cấu hình</translation>
     </message>
@@ -491,7 +491,7 @@
         <translation>Không thể ghi %1 hoàn toàn — đĩa có thể đã đầy. Cấu hình chưa được cập nhật.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1087"/>
+        <location filename="mainwindow.cpp" line="1110"/>
         <source>The config-install script was NOT run:
 
 %1
@@ -508,18 +508,18 @@ Nó không khớp với bản đi kèm phiên bản ứng dụng này. Vì tập
 Hãy cài lại GUI để khôi phục tập lệnh gốc rồi thử lại.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1105"/>
-        <location filename="mainwindow.cpp" line="1117"/>
+        <location filename="mainwindow.cpp" line="1128"/>
+        <location filename="mainwindow.cpp" line="1140"/>
         <source>Installing the config failed (code %1).</source>
         <translation>Cài cấu hình thất bại (mã %1).</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1112"/>
+        <location filename="mainwindow.cpp" line="1135"/>
         <source>The config was installed successfully.</source>
         <translation>Đã cài cấu hình thành công.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1113"/>
+        <location filename="mainwindow.cpp" line="1136"/>
         <source>The config was installed successfully.
 
 %1</source>
@@ -528,7 +528,7 @@ Hãy cài lại GUI để khôi phục tập lệnh gốc rồi thử lại.</tr
 %1</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1118"/>
+        <location filename="mainwindow.cpp" line="1141"/>
         <source>Installing the config failed (code %1).
 
 %2</source>
@@ -537,28 +537,28 @@ Hãy cài lại GUI để khôi phục tập lệnh gốc rồi thử lại.</tr
 %2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1138"/>
-        <location filename="mainwindow.cpp" line="1148"/>
-        <location filename="mainwindow.cpp" line="1155"/>
+        <location filename="mainwindow.cpp" line="1161"/>
+        <location filename="mainwindow.cpp" line="1171"/>
+        <location filename="mainwindow.cpp" line="1178"/>
         <source>Copy PNG</source>
         <translation>Sao chép PNG</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="935"/>
         <location filename="mainwindow.cpp" line="944"/>
-        <location filename="mainwindow.cpp" line="1139"/>
-        <location filename="mainwindow.cpp" line="1149"/>
-        <location filename="mainwindow.cpp" line="1156"/>
+        <location filename="mainwindow.cpp" line="1162"/>
+        <location filename="mainwindow.cpp" line="1172"/>
+        <location filename="mainwindow.cpp" line="1179"/>
         <source>Could not copy %1 to %2</source>
         <translation>Không sao chép được %1 sang %2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1181"/>
+        <location filename="mainwindow.cpp" line="1204"/>
         <source>Invalid PNG</source>
         <translation>PNG không hợp lệ</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1182"/>
+        <location filename="mainwindow.cpp" line="1205"/>
         <source>%1 is not a valid PNG file.
 
 Backgrounds and OS icons must be real PNG images (not just files with a .png extension).</source>
@@ -567,58 +567,58 @@ Backgrounds and OS icons must be real PNG images (not just files with a .png ext
 Hình nền và biểu tượng hệ điều hành phải là ảnh PNG thật (không chỉ là tệp có đuôi .png).</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1445"/>
+        <location filename="mainwindow.cpp" line="1468"/>
         <source>Check For Update</source>
         <translation>Kiểm tra cập nhật</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1448"/>
+        <location filename="mainwindow.cpp" line="1471"/>
         <source>&lt;p align=&apos;center&apos;&gt;&lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd&apos;&gt;rEFInd Customization GUI v%1&lt;/a&gt;&lt;br&gt;&lt;br&gt;Original GUI Creator: &lt;a href=&apos;https://github.com/jlobue10&apos;&gt;jlobue10&lt;/a&gt;&lt;br&gt;&lt;br&gt;Special Thanks to Deck Wizard for testing and QA&lt;br&gt;&lt;br&gt;&lt;a href=&apos;https://www.youtube.com/watch?v=yBHzVSDVEqw&apos;&gt;Deck Wizard Dual Boot Tutorial&lt;/a&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;&lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd&apos;&gt;rEFInd Customization GUI v%1&lt;/a&gt;&lt;br&gt;&lt;br&gt;Người tạo GUI gốc: &lt;a href=&apos;https://github.com/jlobue10&apos;&gt;jlobue10&lt;/a&gt;&lt;br&gt;&lt;br&gt;Cảm ơn đặc biệt Deck Wizard vì đã kiểm thử và đảm bảo chất lượng&lt;br&gt;&lt;br&gt;&lt;a href=&apos;https://www.youtube.com/watch?v=yBHzVSDVEqw&apos;&gt;Hướng dẫn khởi động kép của Deck Wizard&lt;/a&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1497"/>
+        <location filename="mainwindow.cpp" line="1520"/>
         <source>&lt;p align=&apos;center&apos;&gt;Update check failed. Please check your internet connection and try again.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;Kiểm tra cập nhật thất bại. Vui lòng kiểm tra kết nối Internet rồi thử lại.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1500"/>
+        <location filename="mainwindow.cpp" line="1523"/>
         <source>&lt;p align=&apos;center&apos;&gt;An update is available &lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd/releases&apos;&gt;here&lt;/a&gt;&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;Có bản cập nhật &lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd/releases&apos;&gt;tại đây&lt;/a&gt;&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1504"/>
+        <location filename="mainwindow.cpp" line="1527"/>
         <source>&lt;p align=&apos;center&apos;&gt;No update found. You are using the latest version.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;Không có bản cập nhật. Bạn đang dùng phiên bản mới nhất.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1514"/>
-        <location filename="mainwindow.cpp" line="1521"/>
+        <location filename="mainwindow.cpp" line="1537"/>
+        <location filename="mainwindow.cpp" line="1544"/>
         <source>systemd service</source>
         <translation>Dịch vụ systemd</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1515"/>
-        <location filename="mainwindow.cpp" line="1522"/>
+        <location filename="mainwindow.cpp" line="1538"/>
+        <location filename="mainwindow.cpp" line="1545"/>
         <source>Failed to launch the service toggle.</source>
         <translation>Không khởi chạy được việc chuyển đổi dịch vụ.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1528"/>
-        <location filename="mainwindow.cpp" line="1535"/>
+        <location filename="mainwindow.cpp" line="1551"/>
+        <location filename="mainwindow.cpp" line="1558"/>
         <source>Background Randomizer</source>
         <translation>Hình nền ngẫu nhiên</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1529"/>
-        <location filename="mainwindow.cpp" line="1536"/>
-        <location filename="mainwindow.cpp" line="1577"/>
-        <location filename="mainwindow.cpp" line="1584"/>
+        <location filename="mainwindow.cpp" line="1552"/>
+        <location filename="mainwindow.cpp" line="1559"/>
+        <location filename="mainwindow.cpp" line="1600"/>
+        <location filename="mainwindow.cpp" line="1607"/>
         <source>Failed to launch the randomizer setup.</source>
         <translation>Không khởi chạy được thiết lập hình nền ngẫu nhiên.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1546"/>
+        <location filename="mainwindow.cpp" line="1569"/>
         <source>The themes-install script was NOT run:
 
 %1
@@ -635,12 +635,12 @@ Nó bị thiếu, hoặc không khớp với bản đi kèm phiên bản ứng d
 Hãy cài lại GUI (trên SteamOS, chạy lại install-GUI.sh) để cài hoặc khôi phục nó rồi thử lại.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1562"/>
+        <location filename="mainwindow.cpp" line="1585"/>
         <source>The themes were installed successfully.</source>
         <translation>Đã cài các chủ đề thành công.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1563"/>
+        <location filename="mainwindow.cpp" line="1586"/>
         <source>The themes were installed successfully.
 
 %1</source>
@@ -649,12 +649,12 @@ Hãy cài lại GUI (trên SteamOS, chạy lại install-GUI.sh) để cài ho�
 %1</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1567"/>
+        <location filename="mainwindow.cpp" line="1590"/>
         <source>Installing the themes failed (code %1).</source>
         <translation>Cài chủ đề thất bại (mã %1).</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1568"/>
+        <location filename="mainwindow.cpp" line="1591"/>
         <source>Installing the themes failed (code %1).
 
 %2</source>
@@ -663,13 +663,13 @@ Hãy cài lại GUI (trên SteamOS, chạy lại install-GUI.sh) để cài ho�
 %2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1576"/>
-        <location filename="mainwindow.cpp" line="1583"/>
+        <location filename="mainwindow.cpp" line="1599"/>
+        <location filename="mainwindow.cpp" line="1606"/>
         <source>Theme Randomizer</source>
         <translation>Chủ đề ngẫu nhiên</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1591"/>
+        <location filename="mainwindow.cpp" line="1614"/>
         <source>Failed to open %1 in the file manager.</source>
         <translation>Không mở được %1 trong trình quản lý tệp.</translation>
     </message>
@@ -696,22 +696,32 @@ Hãy cài lại GUI (trên SteamOS, chạy lại install-GUI.sh) để cài ho�
 <context>
     <name>PreviewDialog</name>
     <message>
-        <location filename="previewdialog.cpp" line="34"/>
+        <location filename="previewdialog.cpp" line="62"/>
         <source>No boot options selected.</source>
         <translation>Chưa chọn tùy chọn khởi động nào.</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="89"/>
+        <location filename="previewdialog.cpp" line="166"/>
         <source>Preview</source>
         <translation>Xem trước</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="101"/>
+        <location filename="previewdialog.cpp" line="181"/>
         <source>Approximate preview — rEFInd&apos;s real rendering also depends on the firmware resolution and theme.</source>
         <translation>Bản xem trước gần đúng — hiển thị thực tế của rEFInd còn phụ thuộc vào độ phân giải firmware và chủ đề.</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="107"/>
+        <location filename="previewdialog.cpp" line="184"/>
+        <source>Approximate preview showing the randomly picked &quot;%1&quot; theme — Random picks a theme anew each time the config is created.</source>
+        <translation>Bản xem trước gần đúng hiển thị chủ đề &quot;%1&quot; được chọn ngẫu nhiên — &quot;Ngẫu nhiên&quot; chọn một chủ đề mới mỗi lần tạo cấu hình.</translation>
+    </message>
+    <message>
+        <location filename="previewdialog.cpp" line="188"/>
+        <source>Approximate preview with the &quot;%1&quot; theme applied — rEFInd&apos;s real rendering also depends on the firmware resolution and the theme&apos;s other settings.</source>
+        <translation>Bản xem trước gần đúng với chủ đề &quot;%1&quot; được áp dụng — hiển thị thực tế của rEFInd còn phụ thuộc vào độ phân giải firmware và các thiết lập khác của chủ đề.</translation>
+    </message>
+    <message>
+        <location filename="previewdialog.cpp" line="197"/>
         <source>Boot screen</source>
         <translation>Màn hình khởi động</translation>
     </message>

--- a/GUI/src/SteamDeck_rEFInd_zh_CN.ts
+++ b/GUI/src/SteamDeck_rEFInd_zh_CN.ts
@@ -120,7 +120,7 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="468"/>
-        <location filename="mainwindow.cpp" line="1590"/>
+        <location filename="mainwindow.cpp" line="1613"/>
         <source>Open Folder</source>
         <translation>打开文件夹</translation>
     </message>
@@ -280,9 +280,9 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="965"/>
-        <location filename="mainwindow.cpp" line="1545"/>
-        <location filename="mainwindow.cpp" line="1560"/>
-        <location filename="mainwindow.cpp" line="1565"/>
+        <location filename="mainwindow.cpp" line="1568"/>
+        <location filename="mainwindow.cpp" line="1583"/>
+        <location filename="mainwindow.cpp" line="1588"/>
         <source>Install Themes</source>
         <translation>安装主题</translation>
     </message>
@@ -325,10 +325,10 @@
     </message>
     <message>
         <location filename="mainwindow.ui" line="1080"/>
-        <location filename="mainwindow.cpp" line="1086"/>
-        <location filename="mainwindow.cpp" line="1104"/>
-        <location filename="mainwindow.cpp" line="1110"/>
-        <location filename="mainwindow.cpp" line="1115"/>
+        <location filename="mainwindow.cpp" line="1109"/>
+        <location filename="mainwindow.cpp" line="1127"/>
+        <location filename="mainwindow.cpp" line="1133"/>
+        <location filename="mainwindow.cpp" line="1138"/>
         <source>Install Config</source>
         <translation>安装配置</translation>
     </message>
@@ -491,7 +491,7 @@
         <translation>无法完整写入 %1 — 磁盘可能已满。配置未更新。</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1087"/>
+        <location filename="mainwindow.cpp" line="1110"/>
         <source>The config-install script was NOT run:
 
 %1
@@ -508,18 +508,18 @@ Reinstall the GUI to restore the original script, then try again.</source>
 请重新安装 GUI 以恢复原始脚本，然后重试。</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1105"/>
-        <location filename="mainwindow.cpp" line="1117"/>
+        <location filename="mainwindow.cpp" line="1128"/>
+        <location filename="mainwindow.cpp" line="1140"/>
         <source>Installing the config failed (code %1).</source>
         <translation>配置安装失败（代码 %1）。</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1112"/>
+        <location filename="mainwindow.cpp" line="1135"/>
         <source>The config was installed successfully.</source>
         <translation>配置安装成功。</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1113"/>
+        <location filename="mainwindow.cpp" line="1136"/>
         <source>The config was installed successfully.
 
 %1</source>
@@ -528,7 +528,7 @@ Reinstall the GUI to restore the original script, then try again.</source>
 %1</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1118"/>
+        <location filename="mainwindow.cpp" line="1141"/>
         <source>Installing the config failed (code %1).
 
 %2</source>
@@ -537,28 +537,28 @@ Reinstall the GUI to restore the original script, then try again.</source>
 %2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1138"/>
-        <location filename="mainwindow.cpp" line="1148"/>
-        <location filename="mainwindow.cpp" line="1155"/>
+        <location filename="mainwindow.cpp" line="1161"/>
+        <location filename="mainwindow.cpp" line="1171"/>
+        <location filename="mainwindow.cpp" line="1178"/>
         <source>Copy PNG</source>
         <translation>复制 PNG</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="935"/>
         <location filename="mainwindow.cpp" line="944"/>
-        <location filename="mainwindow.cpp" line="1139"/>
-        <location filename="mainwindow.cpp" line="1149"/>
-        <location filename="mainwindow.cpp" line="1156"/>
+        <location filename="mainwindow.cpp" line="1162"/>
+        <location filename="mainwindow.cpp" line="1172"/>
+        <location filename="mainwindow.cpp" line="1179"/>
         <source>Could not copy %1 to %2</source>
         <translation>无法将 %1 复制到 %2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1181"/>
+        <location filename="mainwindow.cpp" line="1204"/>
         <source>Invalid PNG</source>
         <translation>无效的 PNG</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1182"/>
+        <location filename="mainwindow.cpp" line="1205"/>
         <source>%1 is not a valid PNG file.
 
 Backgrounds and OS icons must be real PNG images (not just files with a .png extension).</source>
@@ -567,58 +567,58 @@ Backgrounds and OS icons must be real PNG images (not just files with a .png ext
 背景和系统图标必须是真正的 PNG 图像（而不仅仅是扩展名为 .png 的文件）。</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1445"/>
+        <location filename="mainwindow.cpp" line="1468"/>
         <source>Check For Update</source>
         <translation>检查更新</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1448"/>
+        <location filename="mainwindow.cpp" line="1471"/>
         <source>&lt;p align=&apos;center&apos;&gt;&lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd&apos;&gt;rEFInd Customization GUI v%1&lt;/a&gt;&lt;br&gt;&lt;br&gt;Original GUI Creator: &lt;a href=&apos;https://github.com/jlobue10&apos;&gt;jlobue10&lt;/a&gt;&lt;br&gt;&lt;br&gt;Special Thanks to Deck Wizard for testing and QA&lt;br&gt;&lt;br&gt;&lt;a href=&apos;https://www.youtube.com/watch?v=yBHzVSDVEqw&apos;&gt;Deck Wizard Dual Boot Tutorial&lt;/a&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;&lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd&apos;&gt;rEFInd Customization GUI v%1&lt;/a&gt;&lt;br&gt;&lt;br&gt;GUI 原作者： &lt;a href=&apos;https://github.com/jlobue10&apos;&gt;jlobue10&lt;/a&gt;&lt;br&gt;&lt;br&gt;特别感谢 Deck Wizard 的测试与质量保证&lt;br&gt;&lt;br&gt;&lt;a href=&apos;https://www.youtube.com/watch?v=yBHzVSDVEqw&apos;&gt;Deck Wizard 双系统教程&lt;/a&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1497"/>
+        <location filename="mainwindow.cpp" line="1520"/>
         <source>&lt;p align=&apos;center&apos;&gt;Update check failed. Please check your internet connection and try again.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;检查更新失败。请检查网络连接后重试。&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1500"/>
+        <location filename="mainwindow.cpp" line="1523"/>
         <source>&lt;p align=&apos;center&apos;&gt;An update is available &lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd/releases&apos;&gt;here&lt;/a&gt;&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;有可用更新，请&lt;a href=&apos;https://github.com/jlobue10/SteamDeck_rEFInd/releases&apos;&gt;点击此处&lt;/a&gt;获取&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1504"/>
+        <location filename="mainwindow.cpp" line="1527"/>
         <source>&lt;p align=&apos;center&apos;&gt;No update found. You are using the latest version.&lt;br&gt;&lt;br&gt;&lt;/p&gt;</source>
         <translation>&lt;p align=&apos;center&apos;&gt;未发现更新。您使用的已是最新版本。&lt;br&gt;&lt;br&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1514"/>
-        <location filename="mainwindow.cpp" line="1521"/>
+        <location filename="mainwindow.cpp" line="1537"/>
+        <location filename="mainwindow.cpp" line="1544"/>
         <source>systemd service</source>
         <translation>systemd 服务</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1515"/>
-        <location filename="mainwindow.cpp" line="1522"/>
+        <location filename="mainwindow.cpp" line="1538"/>
+        <location filename="mainwindow.cpp" line="1545"/>
         <source>Failed to launch the service toggle.</source>
         <translation>无法启动服务切换。</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1528"/>
-        <location filename="mainwindow.cpp" line="1535"/>
+        <location filename="mainwindow.cpp" line="1551"/>
+        <location filename="mainwindow.cpp" line="1558"/>
         <source>Background Randomizer</source>
         <translation>背景随机更换</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1529"/>
-        <location filename="mainwindow.cpp" line="1536"/>
-        <location filename="mainwindow.cpp" line="1577"/>
-        <location filename="mainwindow.cpp" line="1584"/>
+        <location filename="mainwindow.cpp" line="1552"/>
+        <location filename="mainwindow.cpp" line="1559"/>
+        <location filename="mainwindow.cpp" line="1600"/>
+        <location filename="mainwindow.cpp" line="1607"/>
         <source>Failed to launch the randomizer setup.</source>
         <translation>无法启动背景随机更换设置。</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1546"/>
+        <location filename="mainwindow.cpp" line="1569"/>
         <source>The themes-install script was NOT run:
 
 %1
@@ -635,12 +635,12 @@ Reinstall the GUI (on SteamOS, re-run install-GUI.sh) to install or restore it, 
 请重新安装 GUI（在 SteamOS 上重新运行 install-GUI.sh）以安装或恢复它，然后重试。</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1562"/>
+        <location filename="mainwindow.cpp" line="1585"/>
         <source>The themes were installed successfully.</source>
         <translation>主题安装成功。</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1563"/>
+        <location filename="mainwindow.cpp" line="1586"/>
         <source>The themes were installed successfully.
 
 %1</source>
@@ -649,12 +649,12 @@ Reinstall the GUI (on SteamOS, re-run install-GUI.sh) to install or restore it, 
 %1</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1567"/>
+        <location filename="mainwindow.cpp" line="1590"/>
         <source>Installing the themes failed (code %1).</source>
         <translation>主题安装失败（代码 %1）。</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1568"/>
+        <location filename="mainwindow.cpp" line="1591"/>
         <source>Installing the themes failed (code %1).
 
 %2</source>
@@ -663,13 +663,13 @@ Reinstall the GUI (on SteamOS, re-run install-GUI.sh) to install or restore it, 
 %2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1576"/>
-        <location filename="mainwindow.cpp" line="1583"/>
+        <location filename="mainwindow.cpp" line="1599"/>
+        <location filename="mainwindow.cpp" line="1606"/>
         <source>Theme Randomizer</source>
         <translation>主题随机更换</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1591"/>
+        <location filename="mainwindow.cpp" line="1614"/>
         <source>Failed to open %1 in the file manager.</source>
         <translation>无法在文件管理器中打开 %1。</translation>
     </message>
@@ -696,22 +696,32 @@ Reinstall the GUI (on SteamOS, re-run install-GUI.sh) to install or restore it, 
 <context>
     <name>PreviewDialog</name>
     <message>
-        <location filename="previewdialog.cpp" line="34"/>
+        <location filename="previewdialog.cpp" line="62"/>
         <source>No boot options selected.</source>
         <translation>未选择任何启动选项。</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="89"/>
+        <location filename="previewdialog.cpp" line="166"/>
         <source>Preview</source>
         <translation>预览</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="101"/>
+        <location filename="previewdialog.cpp" line="181"/>
         <source>Approximate preview — rEFInd&apos;s real rendering also depends on the firmware resolution and theme.</source>
         <translation>近似预览 — rEFInd 的实际显示还取决于固件分辨率和主题。</translation>
     </message>
     <message>
-        <location filename="previewdialog.cpp" line="107"/>
+        <location filename="previewdialog.cpp" line="184"/>
+        <source>Approximate preview showing the randomly picked &quot;%1&quot; theme — Random picks a theme anew each time the config is created.</source>
+        <translation>近似预览，显示随机选中的主题“%1” — “随机”会在每次创建配置时重新选择一个主题。</translation>
+    </message>
+    <message>
+        <location filename="previewdialog.cpp" line="188"/>
+        <source>Approximate preview with the &quot;%1&quot; theme applied — rEFInd&apos;s real rendering also depends on the firmware resolution and the theme&apos;s other settings.</source>
+        <translation>应用主题“%1”后的近似预览 — rEFInd 的实际显示还取决于固件分辨率和该主题的其他设置。</translation>
+    </message>
+    <message>
+        <location filename="previewdialog.cpp" line="197"/>
         <source>Boot screen</source>
         <translation>启动界面</translation>
     </message>

--- a/GUI/src/mainwindow.cpp
+++ b/GUI/src/mainwindow.cpp
@@ -1041,7 +1041,30 @@ void MainWindow::on_Preview_pushButton_clicked()
     if (iconSize <= 0)
         iconSize = 128;
 
-    PreviewDialog dialog(background, entries, iconSize, defaultIndex, confText, this);
+    // The theme include is the last line of the generated config, so the
+    // chosen theme's banner/icon-size/selection supersede the choices above
+    // — resolve the combo choice (Random becomes a concrete pick, as at
+    // Create Config time) and hand the preview its visual directives.
+    PreviewTheme theme;
+    bool randomPick = false;
+    QString themeChoice = ui->Theme_comboBox->currentData().toString();
+    if (themeChoice == QLatin1String(kRandomThemeKey)) {
+        const QStringList themes = availableThemes();
+        themeChoice = themes.isEmpty()
+                          ? QString()
+                          : themes.at(QRandomGenerator::global()->bounded(themes.size()));
+        randomPick = !themeChoice.isEmpty();
+    }
+    if (!themeChoice.isEmpty()) {
+        const QString themesRoot = themesRootDir();
+        theme = PreviewTheme::load(themesRoot + QLatin1Char('/') + themeChoice
+                                       + QStringLiteral("/theme.conf"),
+                                   themesRoot);
+        theme.name = themeChoice;
+        theme.randomPick = randomPick;
+    }
+
+    PreviewDialog dialog(background, entries, iconSize, defaultIndex, theme, confText, this);
     dialog.exec();
 }
 

--- a/GUI/src/previewdialog.cpp
+++ b/GUI/src/previewdialog.cpp
@@ -1,5 +1,7 @@
 #include "previewdialog.h"
 
+#include <QFile>
+#include <QFileInfo>
 #include <QFontMetrics>
 #include <QLabel>
 #include <QPainter>
@@ -7,15 +9,39 @@
 #include <QPixmap>
 #include <QPlainTextEdit>
 #include <QTabWidget>
+#include <QTextStream>
 #include <QVBoxLayout>
 
 namespace {
+
+// Maps a theme.conf asset path onto the local themes directory. The bundled
+// themes are normalized to ESP-relative "themes/<name>/..." paths, but the
+// marker search also accepts an absolute spelling like
+// "/EFI/refind/themes/<name>/..."; anything else is taken relative to the
+// theme.conf itself. Only an existing file is returned — a dangling path
+// must not silently blank the preview element it feeds.
+QString resolveThemeAsset(const QString &value, const QString &themesRoot,
+                          const QString &confDir)
+{
+    if (value.isEmpty())
+        return {};
+    QString rel = value;
+    rel.replace(QLatin1Char('\\'), QLatin1Char('/'));
+    const QString marker = QStringLiteral("themes/");
+    const int idx = rel.indexOf(marker);
+    QString candidate;
+    if (idx >= 0 && !themesRoot.isEmpty())
+        candidate = themesRoot + QLatin1Char('/') + rel.mid(idx + marker.size());
+    else
+        candidate = confDir + QLatin1Char('/') + rel;
+    return QFileInfo::exists(candidate) ? candidate : QString();
+}
 
 // Renders the mock screen at rEFInd's reference geometry (1280x800, the
 // Deck-class panel) and lets the label scale it down; the icon row uses the
 // same proportions rEFInd does for big_icon_size at that resolution.
 QPixmap renderMockScreen(const QString &backgroundPath, const QList<PreviewEntry> &entries,
-                         int iconSize, int defaultIndex)
+                         int iconSize, int defaultIndex, const PreviewTheme &theme)
 {
     const QSize canvas(1280, 800);
     QPixmap pix(canvas);
@@ -24,7 +50,9 @@ QPixmap renderMockScreen(const QString &backgroundPath, const QList<PreviewEntry
     p.setRenderHint(QPainter::SmoothPixmapTransform);
     p.setRenderHint(QPainter::Antialiasing);
 
-    QPixmap bg(backgroundPath);
+    // The theme include is the last line of the config, so its banner and
+    // big_icon_size supersede the user's background and Icon Size choice.
+    QPixmap bg(theme.bannerPath.isEmpty() ? backgroundPath : theme.bannerPath);
     if (!bg.isNull())
         p.drawPixmap(pix.rect(), bg); // banner_scale fillscreen
 
@@ -35,11 +63,19 @@ QPixmap renderMockScreen(const QString &backgroundPath, const QList<PreviewEntry
         return pix;
     }
 
-    const int icon = qBound(48, iconSize, 512);
+    int icon = qBound(48, theme.bigIconSize > 0 ? theme.bigIconSize : iconSize, 512);
+    // Themes aimed at large screens use icon sizes whose row overflows the
+    // 1280-wide mock (rEFInd scrolls in that case); shrink to fit instead so
+    // every entry stays visible. Row width is icon*n + spacing*(n-1) with
+    // spacing = icon/2, i.e. icon*(3n-1)/2.
+    const int maxIcon = 2 * (canvas.width() - 80) / (3 * entries.size() - 1);
+    icon = qMax(48, qMin(icon, maxIcon));
     const int spacing = icon / 2;
     const int rowWidth = entries.size() * icon + (entries.size() - 1) * spacing;
     int x = (canvas.width() - rowWidth) / 2;
     const int y = (canvas.height() - icon) / 2;
+
+    QPixmap selection(theme.selectionPath);
 
     QFont nameFont = p.font();
     nameFont.setPixelSize(qMax(14, icon / 7));
@@ -48,12 +84,19 @@ QPixmap renderMockScreen(const QString &backgroundPath, const QList<PreviewEntry
     for (int i = 0; i < entries.size(); ++i) {
         const QRect iconRect(x, y, icon, icon);
         if (i == defaultIndex) {
-            // rEFInd draws the selection as a light rounded backdrop.
-            QPainterPath path;
-            path.addRoundedRect(iconRect.adjusted(-icon / 8, -icon / 8,
-                                                  icon / 8, icon / 8),
-                                icon / 8, icon / 8);
-            p.fillPath(path, QColor(255, 255, 255, 90));
+            if (!selection.isNull()) {
+                // rEFInd scales selection_big to the big icon size and draws
+                // the icon on top of it.
+                p.drawPixmap(iconRect, selection);
+            } else {
+                // rEFInd draws the default selection as a light rounded
+                // backdrop when the theme brings no selection image.
+                QPainterPath path;
+                path.addRoundedRect(iconRect.adjusted(-icon / 8, -icon / 8,
+                                                      icon / 8, icon / 8),
+                                    icon / 8, icon / 8);
+                p.fillPath(path, QColor(255, 255, 255, 90));
+            }
         }
         QPixmap iconPix(entries.at(i).iconPath);
         if (!iconPix.isNull()) {
@@ -81,9 +124,43 @@ QPixmap renderMockScreen(const QString &backgroundPath, const QList<PreviewEntry
 
 } // namespace
 
+PreviewTheme PreviewTheme::load(const QString &themeConfPath, const QString &themesRoot)
+{
+    PreviewTheme theme;
+    QFile file(themeConfPath);
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
+        return theme;
+    const QString confDir = QFileInfo(themeConfPath).path();
+    QTextStream in(&file);
+    while (!in.atEnd()) {
+        const QString line = in.readLine().trimmed();
+        if (line.isEmpty() || line.startsWith(QLatin1Char('#')))
+            continue;
+        // First whitespace-separated token is the directive; the bundled
+        // themes pad some lines with trailing spaces, hence the trims.
+        int split = 0;
+        while (split < line.size() && !line.at(split).isSpace())
+            ++split;
+        if (split == line.size())
+            continue;
+        const QString directive = line.left(split).toLower();
+        QString value = line.mid(split).trimmed();
+        if (value.size() >= 2 && value.startsWith(QLatin1Char('"'))
+            && value.endsWith(QLatin1Char('"')))
+            value = value.mid(1, value.size() - 2);
+        if (directive == QLatin1String("banner"))
+            theme.bannerPath = resolveThemeAsset(value, themesRoot, confDir);
+        else if (directive == QLatin1String("selection_big"))
+            theme.selectionPath = resolveThemeAsset(value, themesRoot, confDir);
+        else if (directive == QLatin1String("big_icon_size"))
+            theme.bigIconSize = value.section(QLatin1Char(' '), 0, 0).toInt();
+    }
+    return theme;
+}
+
 PreviewDialog::PreviewDialog(const QString &backgroundPath, const QList<PreviewEntry> &entries,
-                             int iconSize, int defaultIndex, const QString &confText,
-                             QWidget *parent)
+                             int iconSize, int defaultIndex, const PreviewTheme &theme,
+                             const QString &confText, QWidget *parent)
     : QDialog(parent)
 {
     setWindowTitle(tr("Preview"));
@@ -95,12 +172,25 @@ PreviewDialog::PreviewDialog(const QString &backgroundPath, const QList<PreviewE
     auto *screenLayout = new QVBoxLayout(screenTab);
     auto *screenLabel = new QLabel(screenTab);
     screenLabel->setAlignment(Qt::AlignCenter);
-    const QPixmap mock = renderMockScreen(backgroundPath, entries, iconSize, defaultIndex);
+    const QPixmap mock = renderMockScreen(backgroundPath, entries, iconSize,
+                                          defaultIndex, theme);
     screenLabel->setPixmap(mock.scaled(720, 450, Qt::KeepAspectRatio,
                                        Qt::SmoothTransformation));
-    auto *note = new QLabel(tr("Approximate preview — rEFInd's real rendering also "
-                               "depends on the firmware resolution and theme."),
-                            screenTab);
+    QString noteText;
+    if (theme.name.isEmpty()) {
+        noteText = tr("Approximate preview — rEFInd's real rendering also "
+                      "depends on the firmware resolution and theme.");
+    } else if (theme.randomPick) {
+        noteText = tr("Approximate preview showing the randomly picked \"%1\" theme — "
+                      "Random picks a theme anew each time the config is created.")
+                       .arg(theme.name);
+    } else {
+        noteText = tr("Approximate preview with the \"%1\" theme applied — rEFInd's "
+                      "real rendering also depends on the firmware resolution and "
+                      "the theme's other settings.")
+                       .arg(theme.name);
+    }
+    auto *note = new QLabel(noteText, screenTab);
     note->setWordWrap(true);
     screenLayout->addWidget(screenLabel, 1);
     screenLayout->addWidget(note);
@@ -114,7 +204,4 @@ PreviewDialog::PreviewDialog(const QString &backgroundPath, const QList<PreviewE
     confView->setFont(mono);
     confView->setPlainText(confText);
     tabs->addTab(confView, QStringLiteral("refind.conf")); // file name, not prose
-
-    auto *layout = new QVBoxLayout(this);
-    layout->addWidget(tabs);
 }

--- a/GUI/src/previewdialog.cpp
+++ b/GUI/src/previewdialog.cpp
@@ -113,10 +113,12 @@ QPixmap renderMockScreen(const QString &backgroundPath, const QList<PreviewEntry
             p.drawText(iconRect, Qt::AlignCenter, entries.at(i).name.left(1));
             p.setFont(nameFont);
         }
-        p.setPen(Qt::white);
-        const QRect nameRect(x - spacing / 2, iconRect.bottom() + icon / 6,
-                             icon + spacing, icon / 3);
-        p.drawText(nameRect, Qt::AlignHCenter | Qt::AlignTop, entries.at(i).name);
+        if (!theme.hideLabel) {
+            p.setPen(Qt::white);
+            const QRect nameRect(x - spacing / 2, iconRect.bottom() + icon / 6,
+                                 icon + spacing, icon / 3);
+            p.drawText(nameRect, Qt::AlignHCenter | Qt::AlignTop, entries.at(i).name);
+        }
         x += icon + spacing;
     }
     return pix;
@@ -148,12 +150,22 @@ PreviewTheme PreviewTheme::load(const QString &themeConfPath, const QString &the
         if (value.size() >= 2 && value.startsWith(QLatin1Char('"'))
             && value.endsWith(QLatin1Char('"')))
             value = value.mid(1, value.size() - 2);
-        if (directive == QLatin1String("banner"))
+        if (directive == QLatin1String("banner")) {
             theme.bannerPath = resolveThemeAsset(value, themesRoot, confDir);
-        else if (directive == QLatin1String("selection_big"))
+        } else if (directive == QLatin1String("selection_big")) {
             theme.selectionPath = resolveThemeAsset(value, themesRoot, confDir);
-        else if (directive == QLatin1String("big_icon_size"))
+        } else if (directive == QLatin1String("big_icon_size")) {
             theme.bigIconSize = value.section(QLatin1Char(' '), 0, 0).toInt();
+        } else if (directive == QLatin1String("hideui")) {
+            // Flags are comma- and/or space-separated; like rEFInd's |=,
+            // repeated hideui lines accumulate (once hidden, stays hidden).
+            const QStringList flags = value.replace(QLatin1Char(','), QLatin1Char(' '))
+                                          .split(QLatin1Char(' '));
+            for (const QString &flag : flags) {
+                if (flag.compare(QLatin1String("label"), Qt::CaseInsensitive) == 0)
+                    theme.hideLabel = true;
+            }
+        }
     }
     return theme;
 }

--- a/GUI/src/previewdialog.h
+++ b/GUI/src/previewdialog.h
@@ -23,6 +23,13 @@ struct PreviewTheme {
     QString bannerPath;      // resolved banner image; empty = user background
     QString selectionPath;   // resolved selection_big image; empty = builtin
     int bigIconSize = 0;     // theme's big_icon_size; 0 = the GUI's icon size
+    // True when the theme's own hideui line lists "label". rEFInd ORs
+    // hideui flags across the base config and the include (config.c:
+    // HideUIFlags |=), so a theme can only hide more, never re-show — and
+    // the GUI's base config already hides label. The mock keeps the names
+    // elsewhere as an identification aid, but a theme that itself asks for
+    // hideui label is drawn without them.
+    bool hideLabel = false;
 
     // Parses the visual directives out of themeConfPath. Asset paths in
     // theme.conf are ESP-relative ("themes/<name>/..."); themesRoot is the

--- a/GUI/src/previewdialog.h
+++ b/GUI/src/previewdialog.h
@@ -12,19 +12,39 @@ struct PreviewEntry {
     QString name;
 };
 
+// The subset of a theme's theme.conf that changes what the mock screen
+// draws. The theme include is the last line of the generated config, so
+// these directives supersede the user's background and icon size — a
+// preview that ignored them would show a boot screen the theme replaces.
+// Default-constructed = no theme (the preview draws the user's choices).
+struct PreviewTheme {
+    QString name;            // theme directory name; empty = no theme
+    bool randomPick = false; // name came from resolving the Random entry
+    QString bannerPath;      // resolved banner image; empty = user background
+    QString selectionPath;   // resolved selection_big image; empty = builtin
+    int bigIconSize = 0;     // theme's big_icon_size; 0 = the GUI's icon size
+
+    // Parses the visual directives out of themeConfPath. Asset paths in
+    // theme.conf are ESP-relative ("themes/<name>/..."); themesRoot is the
+    // local themes directory they resolve against. An asset that does not
+    // resolve to an existing file stays empty, and the preview falls back
+    // to its themeless drawing for that element. Never sets name/randomPick.
+    static PreviewTheme load(const QString &themeConfPath, const QString &themesRoot);
+};
+
 // Approximate mock of the rEFInd boot screen (background, icon row, default
-// selection highlight) plus the generated refind.conf text, so the
-// create -> install -> reboot loop isn't the first time the user sees the
-// result. Purely cosmetic: rEFInd's real rendering also depends on firmware
-// mode and theme details.
+// selection highlight, theme overrides) plus the generated refind.conf text,
+// so the create -> install -> reboot loop isn't the first time the user sees
+// the result. Purely cosmetic: rEFInd's real rendering also depends on
+// firmware mode and theme details the mock doesn't model.
 class PreviewDialog : public QDialog
 {
     Q_OBJECT
 
 public:
     PreviewDialog(const QString &backgroundPath, const QList<PreviewEntry> &entries,
-                  int iconSize, int defaultIndex, const QString &confText,
-                  QWidget *parent = nullptr);
+                  int iconSize, int defaultIndex, const PreviewTheme &theme,
+                  const QString &confText, QWidget *parent = nullptr);
 };
 
 #endif // PREVIEWDIALOG_H


### PR DESCRIPTION
## Summary

The Preview dialog's mock boot screen ignored the Theme selection: it always drew the user's chosen background, slot icons, and Icon Size, even though the theme include is the last line of the generated `refind.conf` and therefore supersedes exactly those settings in rEFInd. With a theme selected, the preview showed a boot screen the theme replaces.

- `PreviewTheme` (in `previewdialog.h`/`.cpp`, kept byte-identical to the sibling rEFInd_GUI repo's copy) parses `banner`, `selection_big`, and `big_icon_size` from the chosen theme's `theme.conf`, resolving the ESP-relative `themes/<name>/...` asset paths against `themesRootDir()`. Assets that don't resolve leave the corresponding preview element on its themeless fallback.
- The mock screen draws the theme's banner instead of the user background, sizes the icon row from the theme's `big_icon_size` (shrinking to fit the 1280-wide mock where real rEFInd would scroll), and draws the theme's `selection_big` image behind the default entry instead of the built-in white backdrop.
- **Random** resolves to a concrete pick per preview; the dialog note explains that Random picks anew at each Create Config. A named theme is called out in the note as well.
- The two new `PreviewDialog` strings are translated in all 20 languages (`scn` added by hand since lupdate refuses it); all `.ts` files refreshed via the `update_translations` target.

Verified: both repos build clean (MSYS2 UCRT64, Qt 6), and `PreviewTheme::load` was exercised against all 7 bundled themes — banners/selection images/icon sizes all resolve, including `rEFInd-mountain`'s trailing-space lines, `Starwars`' uppercase `selection_BIG.png`, and `rEFInd-glassy`'s absent `big_icon_size` (falls back to the GUI's Icon Size).

Sibling PR in rEFInd_GUI carries the identical change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)