### PR TITLE
Add a read-only Install Config diagnostic; retire stale hash-check messages

### DIFF
--- a/NATIVE_HELPER_DESIGN.md
+++ b/NATIVE_HELPER_DESIGN.md
@@ -501,6 +501,14 @@ Development continues on the CachyOS desktop in the sibling rEFInd_GUI repo
 fixes here by copying the parity-locked files (espops/, helper/, tests/)
 and re-applying nothing (espconstants.h stays this repo's own).
 
+If Install Config reports success but the boot screen never changes, run
+the read-only diagnostics first — `scripts/diagnose_install_config.sh`
+(sudo, on the Deck) and `Windows/GUI/diagnose_install_config.ps1`
+(elevated, on Windows). Each one names the ESP the resolver's NVRAM tiers
+would pick, hashes every on-ESP copy of refind.conf against the staged
+source, and flags a fallback `EFI/BOOT/bootx64.efi` rEFInd that a config
+written to `EFI/refind` can never reach.
+
 Deck-specific pass once rEFInd_GUI verification is done:
 
 - `scripts/build_GUI_pinned.sh` must produce BOTH binaries and pass the

--- a/Windows/GUI/diagnose_install_config.ps1
+++ b/Windows/GUI/diagnose_install_config.ps1
@@ -1,0 +1,281 @@
+#Requires -RunAsAdministrator
+# Read-only diagnostic for "Install Config succeeds but nothing changes at
+# boot" (v3.4.0 native-helper flow) -- the Windows counterpart of
+# scripts/diagnose_install_config.sh. Gathers, in one elevated run:
+#
+#   1. every Boot#### NVRAM entry (description, whether its loader path looks
+#      like rEFInd, its GPT partition GUID) and which entry the in-process
+#      resolver's two tiers would match,
+#   2. every ESP-typed partition, with timestamps + SHA-256 of each copy of
+#      EFI\refind\refind.conf and any fallback EFI\BOOT\bootx64.efi,
+#   3. the staged source config under %LOCALAPPDATA%, flagged MATCHES/DIFFERS
+#      against each ESP copy,
+#   4. the tail of the GUI's install log.
+#
+# It never writes NVRAM or any ESP; letterless partitions are mounted on a
+# private temp directory (no drive letter consumed) and unmounted again.
+# Run from an elevated PowerShell:
+#
+#   powershell -NoProfile -ExecutionPolicy Bypass -File .\diagnose_install_config.ps1
+#
+# and attach the full output to the issue/report.
+$ErrorActionPreference = 'Stop'
+
+$EspGuid = '{c12a7328-f81f-11d2-ba4b-00a0c93ec93b}'
+$EfiGlobalGuid = '{8BE4DF61-93CA-11D2-AA0D-00E098032B8C}'
+$DataDir = Join-Path $env:LOCALAPPDATA 'SteamDeck_rEFInd'
+$SrcConf = Join-Path $DataDir 'GUI\refind.conf'
+
+function Write-Section([string]$title) { Write-Host "`n===== $title =====" }
+
+# mountvol reports failure on stderr, which Windows PowerShell 5.1 turns into a
+# terminating RemoteException when redirected under ErrorActionPreference Stop.
+function Invoke-Mountvol([string[]]$mvArgs) {
+    $eap = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try { mountvol @mvArgs 2>$null | Out-Null } finally { $ErrorActionPreference = $eap }
+    return $LASTEXITCODE
+}
+
+# ---- UEFI NVRAM access (read-only here); same block as uninstall_rEFInd.ps1 ----
+Add-Type -Namespace RefindUefi -Name Native -MemberDefinition @'
+[DllImport("kernel32.dll", CharSet=CharSet.Unicode, SetLastError=true)]
+public static extern uint GetFirmwareEnvironmentVariableW(string lpName, string lpGuid, byte[] pBuffer, uint nSize);
+[DllImport("advapi32.dll", SetLastError=true)]
+public static extern bool OpenProcessToken(IntPtr h, uint acc, out IntPtr tok);
+[DllImport("advapi32.dll", CharSet=CharSet.Unicode, SetLastError=true)]
+public static extern bool LookupPrivilegeValueW(string sys, string name, out long luid);
+[DllImport("advapi32.dll", SetLastError=true)]
+public static extern bool AdjustTokenPrivileges(IntPtr tok, bool dis, ref TOKPRIV newst, int len, IntPtr prev, IntPtr ret);
+[DllImport("kernel32.dll")]
+public static extern IntPtr GetCurrentProcess();
+[StructLayout(LayoutKind.Sequential, Pack=4)]
+public struct TOKPRIV { public uint Count; public long Luid; public uint Attr; }
+'@
+
+function Enable-UefiPrivilege {
+    $tok = [IntPtr]::Zero
+    [RefindUefi.Native]::OpenProcessToken([RefindUefi.Native]::GetCurrentProcess(), 0x28, [ref]$tok) | Out-Null
+    $luid = 0L
+    [RefindUefi.Native]::LookupPrivilegeValueW($null, 'SeSystemEnvironmentPrivilege', [ref]$luid) | Out-Null
+    $tp = New-Object RefindUefi.Native+TOKPRIV
+    $tp.Count = 1; $tp.Luid = $luid; $tp.Attr = 2  # SE_PRIVILEGE_ENABLED
+    [RefindUefi.Native]::AdjustTokenPrivileges($tok, $false, [ref]$tp, 0, [IntPtr]::Zero, [IntPtr]::Zero) | Out-Null
+}
+
+function Get-UefiVar([string]$name) {
+    for ($size = 1024; $size -le 1MB; $size *= 2) {
+        $buf = New-Object byte[] $size
+        $n = [RefindUefi.Native]::GetFirmwareEnvironmentVariableW($name, $EfiGlobalGuid, $buf, $buf.Length)
+        if ($n -gt 0) { return ,$buf[0..($n - 1)] }
+        $errorCode = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
+        if ($errorCode -eq 122) { continue }
+        if ($errorCode -eq 2 -or $errorCode -eq 203) { return $null }
+        throw "Reading UEFI variable $name failed with Win32 error $errorCode."
+    }
+    throw "UEFI variable $name exceeds the 1 MiB safety limit."
+}
+
+function Get-BootOrderIds {
+    $bo = Get-UefiVar 'BootOrder'
+    if (-not $bo) { return @() }
+    return @(for ($i = 0; $i + 1 -lt $bo.Length; $i += 2) { '{0:X4}' -f ($bo[$i] + ($bo[$i + 1] * 256)) })
+}
+
+# Minimal EFI_LOAD_OPTION parse, mirroring espops/loadoption.cpp: description,
+# the first GPT hard-drive node's partition GUID, and the first file-path node.
+function Read-LoadOption([byte[]]$bytes) {
+    $r = [pscustomobject]@{ Description = ''; PartitionGuid = ''; LoaderPath = '' }
+    if (-not $bytes -or $bytes.Length -lt 8) { return $r }
+    $filePathListLength = $bytes[4] + ($bytes[5] * 256)
+    $i = 6
+    while ($i + 1 -lt $bytes.Length) {
+        $ch = $bytes[$i] + ($bytes[$i + 1] * 256)
+        $i += 2
+        if ($ch -eq 0) { break }
+        $r.Description += [char]$ch
+    }
+    $pathsEnd = $i + $filePathListLength
+    if ($pathsEnd -gt $bytes.Length) { return $r }
+    while ($i + 4 -le $pathsEnd) {
+        $type = $bytes[$i]; $subType = $bytes[$i + 1]
+        $len = $bytes[$i + 2] + ($bytes[$i + 3] * 256)
+        if ($len -lt 4 -or $i + $len -gt $pathsEnd) { break }
+        if ($type -eq 4 -and $subType -eq 1 -and $len -ge 42 -and
+            $bytes[$i + 41] -eq 2 -and -not $r.PartitionGuid) {
+            # EFI GUIDs: first three fields little-endian, last 8 bytes verbatim.
+            $g = $bytes[($i + 24)..($i + 39)]
+            # [uint32] cast: the byte arithmetic overflows Int32 into Double,
+            # and the x8 format specifier rejects Double.
+            $r.PartitionGuid = ('{0:x8}-{1:x4}-{2:x4}-{3:x2}{4:x2}-{5:x2}{6:x2}{7:x2}{8:x2}{9:x2}{10:x2}' -f `
+                [uint32]([uint32]$g[0] + ([uint32]$g[1] * 256) + ([uint32]$g[2] * 65536) + ([uint32]$g[3] * 16777216)),
+                ($g[4] + ($g[5] * 256)), ($g[6] + ($g[7] * 256)),
+                $g[8], $g[9], $g[10], $g[11], $g[12], $g[13], $g[14], $g[15])
+        } elseif ($type -eq 4 -and $subType -eq 4 -and -not $r.LoaderPath) {
+            $j = $i + 4
+            while ($j + 1 -lt $i + $len) {
+                $ch = $bytes[$j] + ($bytes[$j + 1] * 256)
+                if ($ch -eq 0) { break }
+                $r.LoaderPath += [char]$ch
+                $j += 2
+            }
+        } elseif ($type -eq 0x7F -and $subType -eq 0xFF) {
+            break
+        }
+        $i += $len
+    }
+    return $r
+}
+
+function Test-RefindLoaderPath([string]$p) {
+    return ($p -replace '/', '\') -imatch '\\EFI\\refind\\refind[^\\]*\.efi'
+}
+
+Write-Section 'system'
+Get-Date
+(Get-CimInstance Win32_ComputerSystemProduct).Name
+$app = Join-Path ${env:ProgramFiles} 'SteamDeck_rEFInd'
+foreach ($exe in 'SteamDeck_rEFInd.exe', 'SteamDeck_rEFInd_helper.exe') {
+    $p = Join-Path $app $exe
+    if (Test-Path -LiteralPath $p) {
+        $vi = (Get-Item -LiteralPath $p).VersionInfo
+        Write-Host ("{0}: present (file version {1})" -f $exe, $vi.FileVersion)
+    } else {
+        Write-Host "${exe}: MISSING at $p"
+    }
+}
+Write-Host "data dir: $DataDir"
+
+Write-Section 'firmware boot entries'
+Enable-UefiPrivilege
+$orderIds = Get-BootOrderIds
+Write-Host ("BootOrder: {0}" -f ($(if ($orderIds) { $orderIds -join ',' } else { '(unreadable or empty)' })))
+$candidateIds = @($orderIds + @(0..255 | ForEach-Object { '{0:X4}' -f $_ }) | Select-Object -Unique)
+$entries = @()
+foreach ($id in $candidateIds) {
+    $bytes = Get-UefiVar "Boot$id"
+    if (-not $bytes) { continue }
+    $o = Read-LoadOption $bytes
+    $entries += [pscustomobject]@{ Id = $id; Desc = $o.Description; Loader = $o.LoaderPath; Guid = $o.PartitionGuid }
+    Write-Host ("Boot{0}  '{1}'  loader='{2}'  partition={3}" -f $id, $o.Description, $o.LoaderPath, $o.PartitionGuid)
+}
+
+Write-Section "resolver NVRAM match (what the GUI's tier 1 would pick)"
+$matchGuid = ''
+foreach ($tier in 'loader', 'label') {
+    foreach ($e in $entries) {
+        if (-not $e.Guid) { continue }
+        $hit = if ($tier -eq 'loader') { Test-RefindLoaderPath $e.Loader } else { $e.Desc -ceq 'rEFInd' }
+        if ($hit) {
+            Write-Host ("tier {0} matched: Boot{1} '{2}' -> partition {3}" -f $tier, $e.Id, $e.Desc, $e.Guid)
+            $matchGuid = $e.Guid
+            break
+        }
+    }
+    if ($matchGuid) { break }
+}
+if (-not $matchGuid) { Write-Host 'no rEFInd entry matched by loader path or exact label' }
+
+Write-Section "staged source config ($DataDir\GUI)"
+if (Test-Path -LiteralPath $SrcConf) {
+    Get-ChildItem -LiteralPath (Join-Path $DataDir 'GUI') -File |
+        Where-Object { $_.Name -match '^(refind\.conf|background\.png|os_icon\d\.png|active_theme\.conf)$' } |
+        Format-Table Name, Length, LastWriteTime -AutoSize | Out-Host
+    Write-Host ("SHA256 {0}" -f (Get-FileHash -Algorithm SHA256 -LiteralPath $SrcConf).Hash.ToLower())
+    Write-Host '-- menuentry/include/showtools lines:'
+    Select-String -LiteralPath $SrcConf -Pattern '^\s*(menuentry|include|showtools|default_selection|resolution)' |
+        ForEach-Object { Write-Host ("  {0}: {1}" -f $_.LineNumber, $_.Line) }
+} else {
+    Write-Host 'NO staged refind.conf -- Create Config has not run for this user'
+}
+
+# Every ESP-typed partition: where each copy of the config lives and whether
+# it matches the staged source.
+$tempMounts = @()
+try {
+    foreach ($part in @(Get-Partition | Where-Object { $_.GptType -eq $EspGuid })) {
+        Write-Section ("ESP disk {0} partition {1} (GUID {2})" -f $part.DiskNumber, $part.PartitionNumber, $part.Guid)
+        $partGuidBare = ([guid]$part.Guid).ToString().ToLower()
+        if ($matchGuid -and $partGuidBare -eq $matchGuid) {
+            Write-Host "*** this is the ESP the firmware's rEFInd entry points at ***"
+        }
+        # Letterless partitions serialize DriveLetter as a NUL char, not empty.
+        $root = ''
+        if ($part.DriveLetter -and [int][char]$part.DriveLetter -ge 65) {
+            $root = "$($part.DriveLetter):"
+            Write-Host "already mounted at $root"
+        } else {
+            $volName = @($part.AccessPaths) | Where-Object { $_ -like '\\?\Volume*' } | Select-Object -First 1
+            if (-not $volName) { Write-Host 'no volume access path (skipped)'; continue }
+            $dir = Join-Path $env:TEMP ("sdr-diag-" + [guid]::NewGuid().ToString('N'))
+            New-Item -ItemType Directory -Path $dir | Out-Null
+            if ((Invoke-Mountvol @($dir, $volName)) -eq 0) {
+                $tempMounts += $dir
+                $root = $dir
+                Write-Host "probe-mounted at $dir ($volName)"
+            } else {
+                Remove-Item -LiteralPath $dir -Force -ErrorAction SilentlyContinue
+                Write-Host 'could not mount (skipped)'
+                continue
+            }
+        }
+        $refindDir = Join-Path $root 'EFI\refind'
+        if (Test-Path -LiteralPath $refindDir) {
+            Get-ChildItem -LiteralPath $refindDir -File -ErrorAction SilentlyContinue |
+                Select-Object -First 25 | Format-Table Name, Length, LastWriteTime -AutoSize | Out-Host
+            $espConf = Join-Path $refindDir 'refind.conf'
+            if (Test-Path -LiteralPath $espConf) {
+                $espHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $espConf).Hash.ToLower()
+                Write-Host "SHA256 $espHash"
+                if (Test-Path -LiteralPath $SrcConf) {
+                    $srcHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $SrcConf).Hash.ToLower()
+                    if ($espHash -eq $srcHash) {
+                        Write-Host '>>> refind.conf here MATCHES the staged source'
+                    } else {
+                        Write-Host '>>> refind.conf here DIFFERS from the staged source'
+                    }
+                }
+            } else {
+                Write-Host 'no refind.conf in EFI\refind'
+            }
+            $activeTheme = Join-Path $refindDir 'themes\active_theme.conf'
+            if (Test-Path -LiteralPath $activeTheme) {
+                Get-Item -LiteralPath $activeTheme | Format-Table Name, Length, LastWriteTime -AutoSize | Out-Host
+            }
+        } else {
+            Write-Host 'no EFI\refind directory'
+        }
+        # A rEFInd parked on the fallback path boots without any Boot#### entry
+        # and reads EFI\BOOT\refind.conf -- a write to EFI\refind never reaches it.
+        $fallback = Join-Path $root 'EFI\BOOT\bootx64.efi'
+        if (Test-Path -LiteralPath $fallback) {
+            Get-ChildItem -LiteralPath (Join-Path $root 'EFI\BOOT') -File -ErrorAction SilentlyContinue |
+                Select-Object -First 10 | Format-Table Name, Length, LastWriteTime -AutoSize | Out-Host
+            $probe = [System.IO.File]::ReadAllBytes($fallback)
+            $text = [System.Text.Encoding]::ASCII.GetString($probe)
+            if ($text -imatch 'refind') {
+                Write-Host '>>> EFI\BOOT\bootx64.efi looks like a rEFInd binary (fallback-path install)'
+            }
+        }
+    }
+} finally {
+    foreach ($dir in $tempMounts) {
+        $null = Invoke-Mountvol @($dir, '/D')
+        Remove-Item -LiteralPath $dir -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Write-Section 'GUI install log (last 40 lines)'
+$logDir = Join-Path $DataDir 'GUI\logs'
+if (Test-Path -LiteralPath $logDir) {
+    $latest = Get-ChildItem -LiteralPath $logDir -File | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+    if ($latest) {
+        Write-Host "-- $($latest.FullName):"
+        Get-Content -LiteralPath $latest.FullName -Tail 40
+    }
+} else {
+    Write-Host "no log directory at $logDir"
+}
+
+Write-Section 'done'
+Write-Host 'Attach everything above to the report.'

--- a/install-GUI.sh
+++ b/install-GUI.sh
@@ -60,18 +60,17 @@ if [ -z "$DOWNLOAD_URL" ] || [ "$DOWNLOAD_URL" == "null" ]; then
     exit 1
 fi
 
-# Check out the tag matching the package being installed. The GUI refuses to run
-# the config-install scripts unless they hash-match the copies embedded in the
-# binary at build time, so staging main-branch scripts next to a release binary
-# makes Install Config fail as "possibly tampered with" for every user the
-# moment either script changes after a release.
+# Check out the tag matching the package being installed, so the staged
+# scripts and assets are the ones the released binary expects. (The GUI's
+# privileged actions are version-handshaked against the packaged helper
+# binary, not hash-checked against these scripts any more, but staging
+# main-branch files next to a release binary is still asking for skew.)
 if [ -n "$VERSION" ] && [ "$VERSION" != "null" ]; then
     if git fetch --depth 1 origin "refs/tags/$VERSION:refs/tags/$VERSION" >/dev/null 2>&1 &&
         git checkout -q "$VERSION" >/dev/null 2>&1; then
         printf 'Staging scripts from tag %s.\n' "$VERSION"
     else
         echo "Warning: could not check out $VERSION; staging main-branch scripts instead." >&2
-        echo "If Install Config later reports the script as modified, that is why." >&2
     fi
 fi
 
@@ -241,7 +240,7 @@ if sudo visudo -cf "$CURRENT_WD/sudoers_rule.tmp" > /dev/null 2>&1; then
     echo "Enabled passwordless config install for $INSTALL_USER."
 else
     echo "Warning: the generated sudoers rule failed visudo validation and was NOT installed." >&2
-    echo "Install Config will fall back to asking for your sudo password." >&2
+    echo "Install Config and Install Themes will refuse to run until it is (re-run this installer)." >&2
 fi
 rm -f "$CURRENT_WD/sudoers_rule.tmp"
 

--- a/qa/INSTALL_CONFIG_DEBUG_RUNBOOK.md
+++ b/qa/INSTALL_CONFIG_DEBUG_RUNBOOK.md
@@ -81,3 +81,134 @@ step 2 appear?** Revert the change in the GUI afterwards either way
 Attach all four capture files (`…-before.txt` / `…-after.txt` from both
 OSes) plus the noted dialog lines. The NVRAM dump in them doubles as the
 regression fixture for whatever fix comes out of this.
+
+---
+
+Everything below exists so the investigation can be **finished on the
+device** without the session that produced this branch.
+
+## 6. State of the investigation (handoff)
+
+Symptom (maintainer, Steam Deck OLED, released v3.4.0 on both OSes):
+Install Config shows the success dialog on the Deck **and** on Windows,
+but no change — including boot-entry/order changes — ever appears at
+boot. Boot-entry changes cannot be masked by a theme include, so the
+booting rEFInd is reading a different `refind.conf` than the one being
+written.
+
+Ruled out off-hardware (don't re-investigate these):
+
+- **The staged ESP publish** (`GUI/src/espops/configinstall.cpp`) — unit
+  tested (all six suites green) and exercised end-to-end in a container
+  (root helper + `SUDO_USER` + fake ESP → correct install, exit 0).
+- **The invocation chain** — sudoers template matches the exact argument
+  vectors the GUI runs; version handshake passes (released GUI and helper
+  both embed 3.4.0); dialog/exit-code plumbing audited on both platforms.
+- **The release artifacts** — v3.4.0 pkg contains the helper root-owned at
+  `etc/SteamDeck_rEFInd/`, both binaries need nothing newer than `Qt_6.9`
+  (no pre-`main()` linker abort), Windows deploy ships the helper exe.
+- **Parity skew** — `espops/` + `helper/main.cpp` are byte-identical with
+  rEFInd_GUI HEAD; `espconstants.h` diffs are all intentional.
+
+Established context:
+
+- NVRAM-first ESP targeting is not new in 3.4.0: the bash version shipped
+  in **v3.1.2** (2026-07-26) and the native resolver is a step-for-step
+  port of it (compared tier by tier). If Install Config last visibly
+  worked before 3.1.2, the misbehavior may span 3.1.2–3.3.0 unnoticed.
+- The Deck was **never** part of the hardware verification for this code
+  (rEFInd_GUI NATIVE_HELPER_DESIGN §7.3: Linux verified on a CachyOS
+  desktop only; the Windows pass also ran on the dev machine).
+
+Open hypotheses, in order (the §4 table maps diagnostic output to them):
+
+1. rEFInd actually boots from the fallback path `EFI/BOOT/bootx64.efi`
+   (own `refind.conf` beside it) while installs land in `EFI/refind/`.
+2. Two rEFInd installs on different ESP-typed partitions; NVRAM boots one,
+   the resolver verified-and-wrote the other.
+3. Resolver tier fell through (dialog's `(chosen as …)` says "an ESP
+   containing rEFInd" or "the running system's ESP" instead of "the ESP in
+   the firmware's rEFInd boot entry") and picked a shadow copy.
+
+Code map for the fix, wherever the data points:
+
+- Linux resolver: `GUI/src/espops/espresolve_linux.cpp` —
+  `EspResolver::resolve()` (the three tiers), `refindEspGuidFromNvram()`,
+  `mountPointOf()`/`ensureMounted()`.
+- Windows resolver: `GUI/src/espops/espresolve_win.cpp` — same shape.
+- Shared NVRAM matching: `GUI/src/espops/loadoption.cpp` —
+  `parseLoadOption()`, `loaderLooksLikeRefind()`.
+- Tests: `GUI/src/tests/` (`cmake -DBUILD_GUI_TESTS=ON`, then `ctest`);
+  add the captured NVRAM entry bytes as a `tst_loadoption`/`tst_espresolve`
+  fixture.
+- **Parity rule**: these files are byte-locked with the sibling rEFInd_GUI
+  repo (the implementation lead). Land the fix there, byte-copy `espops/` +
+  `helper/main.cpp` here, re-apply nothing (`espconstants.h` stays this
+  repo's own).
+
+Deck OLED specifics to expect in the diagnostic: DMI product name
+`Galileo`; internal disk `nvme0n1`; **three** ESP-typed partitions on a
+stock Deck — `nvme0n1p1` (label `esp`, where rEFInd lives) plus `efi-A`/
+`efi-B` (SteamOS's A/B `steamcl` partitions, also ESP-typed) — more with
+an SD card inserted. `/esp` and `/efi` are systemd automounts (the
+diagnostic triggers them itself).
+
+## 7. Getting this branch onto the Deck
+
+```
+cd ~ && git clone --branch claude/steamdeck-refind-install-debug-3utkvj --single-branch \
+    https://github.com/jlobue10/SteamDeck_rEFInd SteamDeck_rEFInd-debug
+```
+
+Clone to `~/SteamDeck_rEFInd-debug`, NOT `~/SteamDeck_rEFInd` — the
+release installer owns that path and `rm -rf`s it on every run.
+
+## 8. Applying a candidate fix on the Deck
+
+SteamOS has no compiler; build on any machine with podman using the
+pinned toolchain (this matters — an unpinned build links a newer Qt and
+aborts on-Deck before `main()`):
+
+```
+scripts/build_GUI_pinned.sh          # writes build-pinned/SteamDeck_rEFInd + _helper,
+                                     # asserts Qt <= 6.9 on BOTH binaries
+```
+
+- **Resolver fixes need only the helper** (ESP resolution runs behind sudo
+  on Linux). Hand-place it over the release copy:
+
+  ```
+  sudo install -o root -g root -m 0755 build-pinned/SteamDeck_rEFInd_helper \
+      /etc/SteamDeck_rEFInd/SteamDeck_rEFInd_helper
+  ```
+
+  The version handshake stays green as long as the branch's `project
+  VERSION` stays 3.4.0 (the installed release GUI expects exactly that
+  from `helper --version`). The sudoers rule from the release install
+  keeps matching — the path and argument vectors are unchanged.
+- GUI-side fixes: also replace the copy the desktop entry runs,
+  `~/.local/SteamDeck_rEFInd/GUI/SteamDeck_rEFInd` (the `/usr/bin` copy is
+  optional — a SteamOS update wipes it anyway).
+- Windows-side fixes: the in-process resolver lives in the GUI exe —
+  rebuild in MSYS2 UCRT64 and replace
+  `%ProgramFiles%\SteamDeck_rEFInd\SteamDeck_rEFInd.exe` (elevated), or
+  build the full installer via `Windows/GUI/assemble-deploy.sh` + Inno.
+- Re-run the §2 exercise after placing a fix; §1's diagnostics confirm
+  where the write landed.
+
+## 9. Immediate unblock (no fix required)
+
+If the boot menu must be corrected today regardless of diagnosis, the
+pre-3.1.2 manual path still works for a rEFInd that lives on the Deck's
+own ESP:
+
+```
+ls /esp/. > /dev/null    # trigger the automount
+sudo cp ~/.local/SteamDeck_rEFInd/GUI/refind.conf /esp/efi/refind/refind.conf
+sudo sh -c 'cp ~deck/.local/SteamDeck_rEFInd/GUI/background.png \
+    ~deck/.local/SteamDeck_rEFInd/GUI/os_icon*.png /esp/efi/refind/' 2>/dev/null
+```
+
+Caveat: if the §1 diagnostic shows the booting rEFInd is somewhere else
+(fallback `EFI/BOOT`, SD card, …), copy there instead — blind `/esp`
+writes are exactly the historical failure the resolver was built to end.

--- a/qa/INSTALL_CONFIG_DEBUG_RUNBOOK.md
+++ b/qa/INSTALL_CONFIG_DEBUG_RUNBOOK.md
@@ -1,0 +1,83 @@
+# Install Config "no effect at boot" — hardware debug runbook
+
+For the v3.4.0 report that Install Config shows a success dialog on both
+the Deck and Windows, but changes (including boot-entry/order changes,
+which no theme include can mask) never appear on the boot screen.
+
+What is already established off-hardware:
+
+- The whole install chain (GUI → helper/`espops` → staged ESP publish) is
+  audited, unit-tested, and was exercised end-to-end in a container — the
+  logic itself installs correctly when the target resolution is right.
+- The released v3.4.0 artifacts are sound: helper present, versions
+  matched (handshake passes), Qt symbols ≤ 6.9.
+- The NVRAM-first ESP targeting is semantically identical to the bash
+  version that shipped in v3.1.2, so the misbehavior may be older than
+  3.4.0 and simply unnoticed.
+- Conclusion: the config is being **written somewhere** — the open question
+  is only *where the write lands* vs *where the booting rEFInd reads*.
+  That question can only be answered on the machine.
+
+Everything below is read-only except the one deliberate Install Config
+exercise in step 2. Total time: ~15 minutes plus two reboots.
+
+## 1. Capture diagnostics (both OSes, before touching anything)
+
+### Deck (desktop mode, Konsole)
+
+```
+curl -L -o ~/diag.sh https://raw.githubusercontent.com/jlobue10/SteamDeck_rEFInd/claude/steamdeck-refind-install-debug-3utkvj/scripts/diagnose_install_config.sh
+sudo bash ~/diag.sh 2>&1 | tee ~/refind-diag-deck-before.txt
+```
+
+(Save under `~`, not `/tmp` — `/tmp` does not survive the reboot in step 3.)
+
+### Windows (elevated PowerShell)
+
+```
+curl.exe -L -o "$env:USERPROFILE\diag.ps1" https://raw.githubusercontent.com/jlobue10/SteamDeck_rEFInd/claude/steamdeck-refind-install-debug-3utkvj/Windows/GUI/diagnose_install_config.ps1
+powershell -NoProfile -ExecutionPolicy Bypass -File "$env:USERPROFILE\diag.ps1" 2>&1 | Tee-Object "$env:USERPROFILE\refind-diag-win-before.txt"
+```
+
+Skim each output for the three load-bearing lines before moving on:
+
+- the `resolver NVRAM match` section — did tier `loader` or `label` match,
+  and which partition GUID did it name?
+- under each ESP section: `MATCHES` / `DIFFERS` against the staged source,
+  and whether any partition is flagged
+  `*** this is the ESP the firmware's rEFInd entry points at ***`;
+- any `EFI/BOOT/bootx64.efi looks like a rEFInd binary` flag.
+
+## 2. Controlled Install Config exercise (Deck first, then Windows)
+
+1. Open the GUI. Make one **reversible, unmissable** change — swap Boot
+   Options 1 and 2, or set a slot to None.
+2. Create Config, then Install Config.
+3. Write down the success dialog's last lines — `Installed N file(s) to …`
+   and `(chosen as …)`. (They are also appended to
+   `~/.local/SteamDeck_rEFInd/GUI/logs/` /
+   `%LOCALAPPDATA%\SteamDeck_rEFInd\GUI\logs\`.)
+4. Re-run the step-1 diagnostic into a second file
+   (`…-after.txt`): the ESP that was just written must now say `MATCHES`.
+
+## 3. Reboot and observe
+
+Reboot into the boot menu. Then answer one question: **did the change from
+step 2 appear?** Revert the change in the GUI afterwards either way
+(Create Config + Install Config again).
+
+## 4. Interpret
+
+| Diagnostic result | Boot screen | Diagnosis | Fix direction |
+|---|---|---|---|
+| NVRAM-flagged ESP `MATCHES` after install | changed | No live bug — the original repro was stale (e.g. an attempt predating the 3.4.0 upgrade, or a theme masking a cosmetic-only change). | Close; re-test the original scenario. |
+| NVRAM-flagged ESP `MATCHES` after install | unchanged | The write is correct but the booting rEFInd reads elsewhere. Check the `EFI/BOOT` fallback flag and any *second* ESP whose copy says `DIFFERS` — one of those is what actually boots. | Remove/refresh the fallback copy, or fix NVRAM to boot the real install; consider teaching the resolver to detect a fallback-path rEFInd. |
+| Written ESP `DIFFERS` from the one the firmware flag names (resolver chose a different partition than tier 1 named, or `(chosen as …)` says tier 2/3) | unchanged | Resolver targeting bug — it picked a shadow location. | Fix `espops/espresolve_*` ordering/verification with this NVRAM dump as the test case. |
+| `no rEFInd entry matched by loader path or exact label` | (any) | Tier 1 cannot see the rEFInd entry on this firmware — the `firmware boot entries` dump shows what the entry actually looks like. | Extend the matcher for the Deck's entry shape; the dump is the fixture. |
+| Helper `MISSING`, version mismatch, or sudoers probe `FAILED` (Deck) | — | Install/packaging problem, not resolver — but note this *refuses* with a dialog rather than succeeding, so it cannot explain a success-but-no-effect report. | Re-run install-GUI.sh; if still broken, the diag output shows which piece is absent. |
+
+## 5. Report back
+
+Attach all four capture files (`…-before.txt` / `…-after.txt` from both
+OSes) plus the noted dialog lines. The NVRAM dump in them doubles as the
+regression fixture for whatever fix comes out of this.

--- a/scripts/diagnose_install_config.sh
+++ b/scripts/diagnose_install_config.sh
@@ -1,0 +1,185 @@
+#!/bin/bash
+
+# Read-only diagnostic for "Install Config succeeds but nothing changes at
+# boot" (v3.4.0 native-helper flow). Gathers, in one run, everything needed
+# to tell WHERE the config was written vs WHERE the booting rEFInd reads:
+#
+#   1. the firmware's boot entries (efibootmgr -v) and which one the
+#      resolver's two NVRAM tiers would match,
+#   2. every ESP-typed partition, with the mtime + SHA-256 of each copy of
+#      EFI/refind/refind.conf (and any fallback EFI/BOOT/bootx64.efi),
+#   3. the staged source config under ~/.local, so stale copies stand out,
+#   4. the helper's version handshake + passwordless sudo probe state,
+#   5. the tail of the GUI's install log.
+#
+# It never writes to any ESP: unmounted candidates are probe-mounted
+# ro,nosuid,nodev,noexec on private temp dirs and unmounted again (the same
+# flags the helper's resolver uses). Run it with sudo in desktop mode:
+#
+#   sudo ~/.local/SteamDeck_rEFInd/scripts/diagnose_install_config.sh
+#
+# and attach the full output to the issue/report.
+
+set -u
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "Run this with sudo (ESPs are mounted 0700 root:root)." >&2
+    exit 2
+fi
+
+ESP_TYPE_GUID=c12a7328-f81f-11d2-ba4b-00a0c93ec93b
+HELPER=/etc/SteamDeck_rEFInd/SteamDeck_rEFInd_helper
+# Under sudo $HOME is root's; the staged config belongs to the invoking user.
+USER_HOME="$HOME"
+if [ -n "${SUDO_USER:-}" ] && [ "$SUDO_USER" != "root" ]; then
+    USER_HOME="$(getent passwd "$SUDO_USER" | cut -d: -f6)"
+fi
+SRC_DIR="$USER_HOME/.local/SteamDeck_rEFInd/GUI"
+
+TMPMNT_LIST="$(mktemp)"
+cleanup() {
+    local m
+    while read -r m; do
+        [ -n "$m" ] || continue
+        umount "$m" 2>/dev/null
+        rmdir "$m" 2>/dev/null
+    done < "$TMPMNT_LIST"
+    rm -f "$TMPMNT_LIST"
+}
+trap cleanup EXIT
+
+section() { printf '\n===== %s =====\n' "$1"; }
+
+# Trigger the systemd automounts before reading mount state: a plain stat of
+# the mount point does NOT trigger them (AT_NO_AUTOMOUNT), the trailing /.
+# does, even without permission on the mounted fs.
+for mp in /esp /efi /boot/efi /boot; do
+    stat "$mp/." > /dev/null 2>&1
+done
+
+section "system"
+date
+cat /sys/class/dmi/id/product_name 2>/dev/null
+uname -r
+if [ -x "$HELPER" ]; then
+    printf 'helper: %s (version %s)\n' "$HELPER" "$("$HELPER" --version 2>/dev/null)"
+else
+    echo "helper: MISSING at $HELPER"
+fi
+if [ -n "${SUDO_USER:-}" ] && [ "$SUDO_USER" != "root" ]; then
+    if sudo -n -u "$SUDO_USER" true 2>/dev/null &&
+        runuser -u "$SUDO_USER" -- sudo -n -l "$HELPER" install-config >/dev/null 2>&1; then
+        echo "sudoers: passwordless install-config rule OK for $SUDO_USER"
+    else
+        echo "sudoers: passwordless install-config probe FAILED for $SUDO_USER"
+    fi
+fi
+
+section "firmware boot entries (efibootmgr -v)"
+efibootmgr -v 2>&1
+
+section "resolver NVRAM match (what the helper's tier 1 would pick)"
+EFIBOOT_OUT="$(efibootmgr -v 2>/dev/null)"
+MATCH_GUID=""
+for tier in loader label; do
+    [ -n "$MATCH_GUID" ] && break
+    while read -r line; do
+        if [ "$tier" = loader ]; then
+            grep -qiE '\\EFI\\refind\\refind[^\\]*\.efi' <<< "$line" || continue
+        else
+            # efibootmgr >= 18 appends a tab + device path after the label.
+            sed -nE 's/^Boot[0-9A-Fa-f]{4}\*? +([^\t]*).*/\1/p' <<< "$line" \
+                | grep -qx "rEFInd" || continue
+        fi
+        MATCH_GUID="$(sed -nE 's/.*HD\([0-9]+,GPT,([0-9a-fA-F-]{36}),.*/\1/p' <<< "$line")"
+        if [ -n "$MATCH_GUID" ]; then
+            printf 'tier %s matched: %s\n' "$tier" "$line"
+            printf 'partition GUID: %s\n' "${MATCH_GUID,,}"
+            break
+        fi
+    done <<< "$EFIBOOT_OUT"
+done
+[ -n "$MATCH_GUID" ] || echo "no rEFInd entry matched by loader path or exact label"
+
+section "block devices"
+lsblk -o PATH,SIZE,PARTTYPE,PARTUUID,FSTYPE,LABEL,MOUNTPOINTS 2>&1
+
+section "staged source config ($SRC_DIR)"
+if [ -f "$SRC_DIR/refind.conf" ]; then
+    ls -l "$SRC_DIR/refind.conf" "$SRC_DIR"/background.png \
+        "$SRC_DIR"/os_icon?.png "$SRC_DIR"/active_theme.conf 2>/dev/null
+    sha256sum "$SRC_DIR/refind.conf"
+    echo "-- menuentry/include/showtools lines:"
+    grep -nE '^[[:space:]]*(menuentry|include|showtools|default_selection|resolution)' \
+        "$SRC_DIR/refind.conf"
+else
+    echo "NO staged refind.conf -- Create Config has not run for this user"
+fi
+
+# Every ESP-typed partition: where each copy of the config lives and whether
+# it matches the staged source.
+while read -r dev parttype partuuid; do
+    [ "${parttype,,}" = "$ESP_TYPE_GUID" ] || continue
+    section "ESP $dev (PARTUUID $partuuid)"
+    # findmnt lists the autofs row (SOURCE systemd-1) before the real vfat
+    # row on automounted paths; -S <dev> is immune.
+    mp="$(findmnt -no TARGET -S "$dev" 2>/dev/null | head -1)"
+    mounted_how="already mounted at $mp"
+    if [ -z "$mp" ]; then
+        mp="$(mktemp -d)"
+        if mount -o ro,nosuid,nodev,noexec "$dev" "$mp" 2>/dev/null; then
+            printf '%s\n' "$mp" >> "$TMPMNT_LIST"
+            mounted_how="probe-mounted ro at $mp"
+        else
+            rmdir "$mp" 2>/dev/null
+            echo "could not mount (skipped)"
+            continue
+        fi
+    fi
+    echo "$mounted_how"
+    [ "${partuuid,,}" = "${MATCH_GUID,,}" ] && [ -n "$MATCH_GUID" ] \
+        && echo "*** this is the ESP the firmware's rEFInd entry points at ***"
+    if [ -d "$mp/EFI/refind" ]; then
+        ls -l --time-style=full-iso "$mp/EFI/refind/" 2>/dev/null | head -25
+        if [ -f "$mp/EFI/refind/refind.conf" ]; then
+            sha256sum "$mp/EFI/refind/refind.conf"
+            if [ -f "$SRC_DIR/refind.conf" ]; then
+                if cmp -s "$mp/EFI/refind/refind.conf" "$SRC_DIR/refind.conf"; then
+                    echo ">>> refind.conf here MATCHES the staged source"
+                else
+                    echo ">>> refind.conf here DIFFERS from the staged source"
+                fi
+            fi
+        else
+            echo "no refind.conf in EFI/refind"
+        fi
+        [ -d "$mp/EFI/refind/themes" ] \
+            && ls -l --time-style=full-iso "$mp/EFI/refind/themes/active_theme.conf" 2>/dev/null
+    else
+        echo "no EFI/refind directory"
+    fi
+    # A rEFInd parked on the fallback path boots without any Boot#### entry
+    # and reads EFI/BOOT/refind.conf -- a write to EFI/refind never reaches it.
+    if [ -f "$mp/EFI/BOOT/bootx64.efi" ]; then
+        ls -l --time-style=full-iso "$mp/EFI/BOOT/" 2>/dev/null | head -10
+        if grep -qi refind "$mp/EFI/BOOT/bootx64.efi" 2>/dev/null; then
+            echo ">>> EFI/BOOT/bootx64.efi looks like a rEFInd binary (fallback-path install)"
+        fi
+    fi
+done < <(lsblk -rno PATH,PARTTYPE,PARTUUID 2>/dev/null)
+
+section "GUI install log (last 40 lines)"
+LOGDIR="$SRC_DIR/logs"
+if [ -d "$LOGDIR" ]; then
+    # shellcheck disable=SC2012
+    latest="$(ls -1t "$LOGDIR" 2>/dev/null | head -1)"
+    if [ -n "$latest" ]; then
+        echo "-- $LOGDIR/$latest:"
+        tail -40 "$LOGDIR/$latest"
+    fi
+else
+    echo "no log directory at $LOGDIR"
+fi
+
+section "done"
+echo "Attach everything above to the report."


### PR DESCRIPTION
scripts/diagnose_install_config.sh captures, in one sudo run, everything
needed to explain 'Install Config succeeds but nothing changes at boot':
the firmware's boot entries and which one the helper's NVRAM tiers would
match, every ESP-typed partition with the mtime/SHA-256 of its
EFI/refind/refind.conf (probe-mounted ro like the resolver, never
written), a fallback EFI/BOOT/bootx64.efi check, the staged source config
vs each ESP copy, the helper version handshake + sudoers probe, and the
GUI log tail.

install-GUI.sh: the visudo-failure and tag-checkout messages still
described the pre-3.4.0 script hash-check and zenity password fallback,
both of which are gone -- Install Config is passwordless-only now.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014qh5hQ4rY5Sib6HmXK3aXB