### PR TITLE
Reference Ventoy/Batocera stanzas by partition GUID, not label

### DIFF
--- a/GUI/src/osdetect_common.cpp
+++ b/GUI/src/osdetect_common.cpp
@@ -219,14 +219,17 @@ QList<BootEntry> OSDetector::assembleEntries(const QList<Partition> &partitions,
 
     for (const Partition &p : partitions) {
         // Removable media recognized by well-known labels, ESP-typed or not.
+        // The stanza still references the volume by partition GUID: rEFInd can
+        // drop a label-matched stanza even with the medium present, and the
+        // GUID is unique where labels need not be.
         if (p.label.compare(QLatin1String("BATOCERA"), Qt::CaseInsensitive) == 0) {
             addUnique({QStringLiteral("Batocera"), QStringLiteral("Batocera"),
-                       QStringLiteral("/EFI/BOOT/bootx64.efi"), QStringLiteral("BATOCERA"), false});
+                       QStringLiteral("/EFI/BOOT/bootx64.efi"), espVolumeId(p), false});
             continue;
         }
         if (p.label.compare(QLatin1String("VTOYEFI"), Qt::CaseInsensitive) == 0) {
             addUnique({QStringLiteral("Ventoy"), QStringLiteral("Ventoy"),
-                       QStringLiteral("/EFI/BOOT/grubx64_real.efi"), QStringLiteral("VTOYEFI"), false});
+                       QStringLiteral("/EFI/BOOT/grubx64_real.efi"), espVolumeId(p), false});
             continue;
         }
         if (!isEsp(p) || !p.mountPoint.isEmpty())


### PR DESCRIPTION
## Summary
Parity port of jlobue10/rEFInd_GUI#91.

On-hardware diagnosis of the "Install Config has no effect" report ended at a different defect than the config install chain (that chain was verified working end-to-end): rEFInd silently drops the generated Ventoy menuentry, whose `volume` was the filesystem label `VTOYEFI`.

An A/B test config installed on the Deck's ESP carried both stanzas — the original label-based one and an identical one referencing the same partition by GUID. After ruling out an unseated SD card (which explains earlier zero-icon boots: rEFInd correctly skips a stanza whose volume doesn't exist), the reseated-card boot showed **one** Ventoy icon, not two — i.e. one stanza still dropped. Final title confirmation from the next boot is pending, but the GUID reference is strictly more robust either way: partition GUIDs are unique and stable where labels need not be.

## Change
- `GUI/src/osdetect_common.cpp`: the Ventoy and Batocera stanzas keep label-based *detection* but now emit `espVolumeId(p)` (partition GUID, label fallback) as the stanza `volume` — the same convention the Windows stanzas already use.
- The label-based fallback combo options in `mainwindow.cpp` are intentionally unchanged: they exist for media not currently inserted, where no GUID is knowable, and they dedupe against detected entries by display name.

## Testing
- Built clean via `scripts/build_GUI_pinned.sh` (`arch-pinned:steamos`, Arch snapshot 2025/07/30, Qt 6.9).
- On-hardware verification on the Deck follows once the pending boot confirms which stanza title survived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P7jfSfqreuz3oAwQidQ72