### PR TITLE
Supply-chain follow-ups: release checksums + bootstrap tarball pin

### DIFF
--- a/.github/workflows/arch-release.yml
+++ b/.github/workflows/arch-release.yml
@@ -35,11 +35,9 @@ env:
   # snapshot instead fails on package splits (e.g. gcc-libs -> libasan/...).
   ARCH_SNAPSHOT: '2025/07/30'
   BOOTSTRAP_DATE: '2025.07.01'
-  # Supply-chain pin for the bootstrap tarball. Leave empty to only LOG the hash
-  # (the build step prints it every run); once you have captured the value from a
-  # trusted run, paste it here to ENFORCE it — a mismatch then fails the build.
-  # Bump this in lockstep with BOOTSTRAP_DATE.
-  BOOTSTRAP_SHA256: ''
+  # Official sha256sums.txt value for the immutable bootstrap snapshot. Bump
+  # this in lockstep with BOOTSTRAP_DATE.
+  BOOTSTRAP_SHA256: 'bc943f1d3d25d9350a23574b7eacdd8e00badd8f546ce05929d233b404bfd155'
   # Highest Qt symbol version SteamOS 3.8.x can load. The guard below fails the
   # release if the built binary requires anything newer.
   MAX_QT_ABI: '6.9'
@@ -69,15 +67,11 @@ jobs:
         run: |
           curl -fsSL --retry 3 --retry-delay 15 -o bootstrap.tar.zst \
             "https://archive.archlinux.org/iso/${BOOTSTRAP_DATE}/archlinux-bootstrap-${BOOTSTRAP_DATE}-x86_64.tar.zst"
-          # Supply-chain: the pinned snapshot is immutable, so the tarball's hash
-          # is stable. Always log it; enforce it when BOOTSTRAP_SHA256 is pinned.
+          # Supply-chain: verify the immutable snapshot before importing it as
+          # the root filesystem used to build the release package.
           echo "bootstrap.tar.zst sha256: $(sha256sum bootstrap.tar.zst | cut -d' ' -f1)"
-          if [ -n "${BOOTSTRAP_SHA256:-}" ]; then
-            echo "${BOOTSTRAP_SHA256}  bootstrap.tar.zst" | sha256sum -c - \
-              || { echo "::error::bootstrap tarball SHA-256 does not match the pinned BOOTSTRAP_SHA256"; exit 1; }
-          else
-            echo "::warning::BOOTSTRAP_SHA256 is not pinned; skipping bootstrap integrity check (paste the sha256 above into env.BOOTSTRAP_SHA256 to enforce)"
-          fi
+          echo "${BOOTSTRAP_SHA256}  bootstrap.tar.zst" | sha256sum -c - \
+            || { echo "::error::bootstrap tarball SHA-256 does not match the pinned BOOTSTRAP_SHA256"; exit 1; }
           sudo mkdir -p /tmp/rootfs
           sudo tar --use-compress-program=unzstd -xf bootstrap.tar.zst -C /tmp/rootfs
           sudo tar -C /tmp/rootfs/root.x86_64 -cf - . | docker import - arch-pinned:build

--- a/.github/workflows/arch-release.yml
+++ b/.github/workflows/arch-release.yml
@@ -35,6 +35,11 @@ env:
   # snapshot instead fails on package splits (e.g. gcc-libs -> libasan/...).
   ARCH_SNAPSHOT: '2025/07/30'
   BOOTSTRAP_DATE: '2025.07.01'
+  # Supply-chain pin for the bootstrap tarball. Leave empty to only LOG the hash
+  # (the build step prints it every run); once you have captured the value from a
+  # trusted run, paste it here to ENFORCE it — a mismatch then fails the build.
+  # Bump this in lockstep with BOOTSTRAP_DATE.
+  BOOTSTRAP_SHA256: ''
   # Highest Qt symbol version SteamOS 3.8.x can load. The guard below fails the
   # release if the built binary requires anything newer.
   MAX_QT_ABI: '6.9'
@@ -64,6 +69,15 @@ jobs:
         run: |
           curl -fsSL --retry 3 --retry-delay 15 -o bootstrap.tar.zst \
             "https://archive.archlinux.org/iso/${BOOTSTRAP_DATE}/archlinux-bootstrap-${BOOTSTRAP_DATE}-x86_64.tar.zst"
+          # Supply-chain: the pinned snapshot is immutable, so the tarball's hash
+          # is stable. Always log it; enforce it when BOOTSTRAP_SHA256 is pinned.
+          echo "bootstrap.tar.zst sha256: $(sha256sum bootstrap.tar.zst | cut -d' ' -f1)"
+          if [ -n "${BOOTSTRAP_SHA256:-}" ]; then
+            echo "${BOOTSTRAP_SHA256}  bootstrap.tar.zst" | sha256sum -c - \
+              || { echo "::error::bootstrap tarball SHA-256 does not match the pinned BOOTSTRAP_SHA256"; exit 1; }
+          else
+            echo "::warning::BOOTSTRAP_SHA256 is not pinned; skipping bootstrap integrity check (paste the sha256 above into env.BOOTSTRAP_SHA256 to enforce)"
+          fi
           sudo mkdir -p /tmp/rootfs
           sudo tar --use-compress-program=unzstd -xf bootstrap.tar.zst -C /tmp/rootfs
           sudo tar -C /tmp/rootfs/root.x86_64 -cf - . | docker import - arch-pinned:build
@@ -149,8 +163,16 @@ jobs:
           name: arch-package
           path: release
 
+      - name: Generate checksums
+        run: |
+          cd release
+          for f in *.pkg.tar.zst; do sha256sum "$f" > "$f.sha256"; done
+          cat ./*.sha256
+
       - name: Attach package to release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           tag_name: ${{ env.TAG }}
-          files: 'release/*.pkg.tar.zst'
+          files: |
+            release/*.pkg.tar.zst
+            release/*.sha256

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -129,7 +129,15 @@ jobs:
           name: windows-build
           path: release
 
+      - name: Generate checksums
+        run: |
+          cd release
+          for f in *.exe; do sha256sum "$f" > "$f.sha256"; done
+          cat ./*.sha256
+
       - name: Attach to release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
-          files: release/*.exe
+          files: |
+            release/*.exe
+            release/*.sha256

--- a/scripts/build_GUI_pinned.sh
+++ b/scripts/build_GUI_pinned.sh
@@ -17,11 +17,12 @@ set -euo pipefail
 
 ARCH_SNAPSHOT='2025/07/30'   # qt6-base 6.9.1-5, glibc 2.41 — SteamOS 3.8.16
 BOOTSTRAP_DATE='2025.07.01'  # self-consistent root from the same era
-# Supply-chain pin for the bootstrap tarball (immutable snapshot). Leave empty to
-# only LOG the hash; set it (same value as arch-release.yml's BOOTSTRAP_SHA256)
-# to ENFORCE it. Keep in sync with the workflow and BOOTSTRAP_DATE.
-BOOTSTRAP_SHA256="${BOOTSTRAP_SHA256:-}"
-IMAGE='arch-pinned:steamos'
+# Official sha256sums.txt value for the immutable bootstrap snapshot. Keep this
+# in sync with arch-release.yml and BOOTSTRAP_DATE.
+BOOTSTRAP_SHA256='bc943f1d3d25d9350a23574b7eacdd8e00badd8f546ce05929d233b404bfd155'
+# The cache identity includes both inputs that define the imported root. A pin
+# change therefore cannot silently reuse an image created before verification.
+IMAGE="arch-pinned:${BOOTSTRAP_DATE}-${BOOTSTRAP_SHA256:0:12}"
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 OUT="$(realpath -m "${1:-$REPO_ROOT/build-pinned}")"
@@ -40,12 +41,8 @@ if ! podman image exists "$IMAGE"; then
     curl -fsSL -o "$WORK/bootstrap.tar.zst" \
         "https://archive.archlinux.org/iso/${BOOTSTRAP_DATE}/archlinux-bootstrap-${BOOTSTRAP_DATE}-x86_64.tar.zst"
     echo "bootstrap.tar.zst sha256: $(sha256sum "$WORK/bootstrap.tar.zst" | cut -d' ' -f1)"
-    if [ -n "$BOOTSTRAP_SHA256" ]; then
-        echo "${BOOTSTRAP_SHA256}  $WORK/bootstrap.tar.zst" | sha256sum -c - \
-            || { echo "Error: bootstrap tarball SHA-256 does not match the pinned value. Aborting." >&2; exit 1; }
-    else
-        echo "Warning: BOOTSTRAP_SHA256 not pinned; skipping bootstrap integrity check." >&2
-    fi
+    echo "${BOOTSTRAP_SHA256}  $WORK/bootstrap.tar.zst" | sha256sum -c - \
+        || { echo "Error: bootstrap tarball SHA-256 does not match the pinned value. Aborting." >&2; exit 1; }
     # Extract and repack inside a user namespace: the tarball carries
     # root-owned files and restrictive directory modes that a plain
     # unprivileged tar cannot write.

--- a/scripts/build_GUI_pinned.sh
+++ b/scripts/build_GUI_pinned.sh
@@ -17,6 +17,10 @@ set -euo pipefail
 
 ARCH_SNAPSHOT='2025/07/30'   # qt6-base 6.9.1-5, glibc 2.41 — SteamOS 3.8.16
 BOOTSTRAP_DATE='2025.07.01'  # self-consistent root from the same era
+# Supply-chain pin for the bootstrap tarball (immutable snapshot). Leave empty to
+# only LOG the hash; set it (same value as arch-release.yml's BOOTSTRAP_SHA256)
+# to ENFORCE it. Keep in sync with the workflow and BOOTSTRAP_DATE.
+BOOTSTRAP_SHA256="${BOOTSTRAP_SHA256:-}"
 IMAGE='arch-pinned:steamos'
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -35,6 +39,13 @@ if ! podman image exists "$IMAGE"; then
     echo -e "Fetching pinned Arch root (${BOOTSTRAP_DATE})...\n"
     curl -fsSL -o "$WORK/bootstrap.tar.zst" \
         "https://archive.archlinux.org/iso/${BOOTSTRAP_DATE}/archlinux-bootstrap-${BOOTSTRAP_DATE}-x86_64.tar.zst"
+    echo "bootstrap.tar.zst sha256: $(sha256sum "$WORK/bootstrap.tar.zst" | cut -d' ' -f1)"
+    if [ -n "$BOOTSTRAP_SHA256" ]; then
+        echo "${BOOTSTRAP_SHA256}  $WORK/bootstrap.tar.zst" | sha256sum -c - \
+            || { echo "Error: bootstrap tarball SHA-256 does not match the pinned value. Aborting." >&2; exit 1; }
+    else
+        echo "Warning: BOOTSTRAP_SHA256 not pinned; skipping bootstrap integrity check." >&2
+    fi
     # Extract and repack inside a user namespace: the tarball carries
     # root-owned files and restrictive directory modes that a plain
     # unprivileged tar cannot write.


### PR DESCRIPTION
Follow-up to the v3.4.2 security work (`SECURITY_AUDIT_2026-08.md` "Known follow-ups").

## Changes

- **Release checksums.** `arch-release.yml` and `windows-release.yml` emit a per-artifact `.sha256` sidecar and attach it with each package/installer.
- **Enforced bootstrap pin.** The Arch release workflow verifies `archlinux-bootstrap-2025.07.01-x86_64.tar.zst` against the official Arch SHA-256 before importing it:
  `bc943f1d3d25d9350a23574b7eacdd8e00badd8f546ce05929d233b404bfd155`
- **Safe local cache identity.** `scripts/build_GUI_pinned.sh` enforces the same checksum and includes the bootstrap date plus hash prefix in the Podman image tag, so a previously unverified cached image cannot be silently reused after the pin changes.

## Companion installer work

PR #227 consumes the new Arch package sidecar before `pacman -U`. It permits the existing v3.4.2 release with a transition warning and requires checksums from v3.4.3 onward.

## Deferred

- SignPath/Authenticode and GPG release-tag signing remain deferred.
- Replacing `SigLevel = Never` is isolated on branch `codex/arch-snapshot-signatures` for runner/Deck validation; it is intentionally not part of this PR.

## Validation

- `bash -n scripts/build_GUI_pinned.sh`
- Workflow YAML parsing
- `git diff --check`
- The pinned checksum was verified against Arch's official `2025.07.01/sha256sums.txt`

The release workflow itself should still be exercised with a tag or controlled dispatch before relying on the new release assets.