### PR TITLE
Verify release tag GPG signature before building (opt-in)

### DIFF
--- a/.github/release-signing-key.asc
+++ b/.github/release-signing-key.asc
@@ -1,0 +1,14 @@
+Placeholder — no release signing key is configured yet.
+
+Replace the entire contents of this file with the ASCII-armored PUBLIC key that
+signs release tags, e.g.:
+
+    gpg --armor --export <your-key-fingerprint> > .github/release-signing-key.asc
+
+Until this file contains a real key block (a line beginning
+"-----BEGIN PGP PUBLIC KEY BLOCK-----"), the "Verify release tag signature"
+step in the release workflows only warns and is skipped, so nothing breaks.
+Once a real key is committed here AND tags are created with `git tag -s`,
+verification becomes enforcing automatically.
+
+See SIGNING-TAGS.md for the full setup.

--- a/.github/workflows/arch-release.yml
+++ b/.github/workflows/arch-release.yml
@@ -52,6 +52,25 @@ jobs:
       # current recipe, and the pkgver guard below keeps the pairing honest.
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
+      - name: Verify release tag signature
+        env:
+          TAG: ${{ env.TAG }}
+        run: |
+          set -euo pipefail
+          KEY=.github/release-signing-key.asc
+          if [ -f "$KEY" ] && grep -q 'BEGIN PGP PUBLIC KEY BLOCK' "$KEY"; then
+            echo "Verifying signature of tag $TAG against the committed release key..."
+            gpg --quiet --import "$KEY"
+            git fetch --force origin "refs/tags/${TAG}:refs/tags/${TAG}"
+            if ! git verify-tag "$TAG"; then
+              echo "::error::Tag $TAG is not signed by the trusted release key (must be an annotated tag made with 'git tag -s')."
+              exit 1
+            fi
+            echo "Tag signature verified."
+          else
+            echo "::warning::No release signing key committed at $KEY yet; skipping tag signature verification. See SIGNING-TAGS.md to enable."
+          fi
+
       - name: Check PKGBUILD pkgver matches the tag
         run: |
           pkgver="$(sed -n 's/^pkgver=//p' PKGBUILD)"

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -23,6 +23,27 @@ jobs:
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
+      - name: Verify release tag signature
+        if: startsWith(github.ref, 'refs/tags/')
+        shell: bash
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          KEY=.github/release-signing-key.asc
+          if [ -f "$KEY" ] && grep -q 'BEGIN PGP PUBLIC KEY BLOCK' "$KEY"; then
+            echo "Verifying signature of tag $TAG against the committed release key..."
+            gpg --quiet --import "$KEY"
+            git fetch --force origin "refs/tags/${TAG}:refs/tags/${TAG}"
+            if ! git verify-tag "$TAG"; then
+              echo "::error::Tag $TAG is not signed by the trusted release key (must be an annotated tag made with 'git tag -s')."
+              exit 1
+            fi
+            echo "Tag signature verified."
+          else
+            echo "::warning::No release signing key committed at $KEY yet; skipping tag signature verification. See SIGNING-TAGS.md to enable."
+          fi
+
       - name: Set up MSYS2 (UCRT64)
         uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2
         with:

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -19,6 +19,13 @@ source=(
 md5sums=(
     'SKIP'
 )
+# Enforce a signed release tag: once release tags are created with `git tag -s`,
+# uncomment this with the signing key's full fingerprint. makepkg then refuses to
+# build unless the cloned tag is signed by that key — protecting local/AUR builds
+# the same way the CI "Verify release tag signature" step protects the workflow.
+# See SIGNING-TAGS.md. (Leave commented until tags are actually signed, or every
+# makepkg run will fail on the unsigned tag.)
+#validpgpkeys=('REPLACE_WITH_RELEASE_KEY_FINGERPRINT')
 
 prepare() {
     cd $_pkgname

--- a/SIGNING-TAGS.md
+++ b/SIGNING-TAGS.md
@@ -1,0 +1,60 @@
+# Signing release tags
+
+Release builds clone a git **tag**, which is mutable — anyone with push access
+could move `vX.Y.Z` to a different commit and CI would repackage it. Signing the
+tag and verifying the signature at build time closes that gap.
+
+This is **opt-in and non-breaking**: until a real public key is committed to
+`.github/release-signing-key.asc`, the "Verify release tag signature" step in
+every release workflow only prints a warning and continues, and the PKGBUILD's
+`validpgpkeys` line stays commented. Nothing changes for the current pipeline
+(whose existing tags are unsigned) until you deliberately turn it on.
+
+## One-time setup
+
+1. **Create a signing key** (if you don't already have one):
+
+   ```
+   gpg --full-generate-key        # choose ECC (ed25519) or RSA 4096
+   gpg --list-secret-keys --keyid-format=long   # note the fingerprint
+   ```
+
+2. **Commit the PUBLIC key** (never the private key) so builds can verify:
+
+   ```
+   gpg --armor --export <FINGERPRINT> > .github/release-signing-key.asc
+   git add .github/release-signing-key.asc && git commit -m "Add release signing public key"
+   ```
+
+   The file must contain a real `-----BEGIN PGP PUBLIC KEY BLOCK-----`; that is
+   what flips the CI step from warn-only to enforcing.
+
+3. **Enable AUR/local enforcement** (optional but recommended): in `PKGBUILD`,
+   uncomment `validpgpkeys=(...)` and set it to your key's full fingerprint.
+   `makepkg` then refuses to build unless the cloned tag is signed by that key.
+
+## Every release
+
+Create the tag as an **annotated, signed** tag (lightweight tags cannot be
+signed):
+
+```
+git tag -s vX.Y.Z -m "vX.Y.Z"
+git push origin vX.Y.Z
+```
+
+Or set it once globally: `git config --global tag.gpgSign true` (then `git tag`
+signs automatically). Confirm locally with `git verify-tag vX.Y.Z`.
+
+## Notes
+
+- **Existing unsigned tags won't verify.** Once the key is committed, rebuilding
+  a pre-signing release (e.g. an old `workflow_dispatch` on `vX.Y.Z`) will fail
+  the verify step — that is expected. Enforce going forward; don't retro-rebuild
+  unsigned tags, or sign them retroactively (`git tag -s -f`, which rewrites the
+  tag) if you must.
+- The CI step imports the committed public key into an ephemeral runner keyring
+  and runs `git verify-tag`. It does not need any secret.
+- This is independent of Authenticode/SignPath binary signing (see
+  `Windows/GUI/SIGNING.md`); tag signing protects the *source* a build packages,
+  binary signing protects the *artifact* users download.


### PR DESCRIPTION
Follow-up to the v3.4.2 security work — the supply-chain item the checksums PR (#225) deliberately left out. Release builds clone a **mutable git tag**, so anyone with push access could move `vX.Y.Z` to a different commit and CI would repackage it. This adds signed-tag verification.

**Opt-in and non-breaking.** Until you commit a real public key to `.github/release-signing-key.asc` (a placeholder is committed for now) *and* start making signed tags, the verify step only **warns and continues**, and the PKGBUILD guard stays commented — so the current pipeline (whose tags are unsigned) is completely unaffected. It becomes enforcing automatically once the key is present.

## Changes
- **`arch-release.yml` / `windows-release.yml`** — a `Verify release tag signature` step (in the *build* job) imports the committed public key and runs `git verify-tag $TAG`, failing the build on an unsigned/untrusted tag. It's placed in the build job specifically so it doesn't overlap the release-job checksum step in #225 (no merge conflict between the two PRs).
- **`PKGBUILD`** — a commented `validpgpkeys=(...)` line so local/AUR `makepkg` builds enforce the same signed tag once you fill in the fingerprint and sign tags.
- **`SIGNING-TAGS.md`** — how to create a key, sign tags (`git tag -s`), commit the public key, and turn enforcement on; plus the caveat that pre-signing tags won't verify.
- **`.github/release-signing-key.asc`** — placeholder; replace with your armored public key to activate.

## To turn it on (your action)
1. `gpg --armor --export <FPR> > .github/release-signing-key.asc` and commit it.
2. Uncomment `validpgpkeys` in `PKGBUILD` with the fingerprint.
3. Sign release tags going forward: `git tag -s vX.Y.Z -m "vX.Y.Z"` (or `git config tag.gpgSign true`).

## Validation
YAML validated; PKGBUILD parses. The verify step itself hasn't run in CI — worth a throwaway signed-tag dispatch to confirm once you've set up a key. The companion follow-up is the checksums PR #225; the rEFInd_GUI equivalent of this PR is jlobue10/rEFInd_GUI#94 (opening now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196v7HCcvq3AdutY8W2Aup1

---
_Generated by [Claude Code](https://claude.ai/code/session_0196v7HCcvq3AdutY8W2Aup1)_