### PR TITLE
Fix signed-tag guard false-matching the placeholder key (unblocks release)

### DIFF
--- a/.github/release-signing-key.asc
+++ b/.github/release-signing-key.asc
@@ -5,10 +5,9 @@ signs release tags, e.g.:
 
     gpg --armor --export <your-key-fingerprint> > .github/release-signing-key.asc
 
-Until this file contains a real key block (a line beginning
-"-----BEGIN PGP PUBLIC KEY BLOCK-----"), the "Verify release tag signature"
-step in the release workflows only warns and is skipped, so nothing breaks.
-Once a real key is committed here AND tags are created with `git tag -s`,
-verification becomes enforcing automatically.
+Until this file starts with a real armored public-key header line, the "Verify
+release tag signature" step in the release workflows only warns and is skipped,
+so nothing breaks. Once a real key is committed here AND tags are created with
+`git tag -s`, verification becomes enforcing automatically.
 
 See SIGNING-TAGS.md for the full setup.

--- a/.github/workflows/arch-release.yml
+++ b/.github/workflows/arch-release.yml
@@ -61,7 +61,7 @@ jobs:
         run: |
           set -euo pipefail
           KEY=.github/release-signing-key.asc
-          if [ -f "$KEY" ] && grep -q 'BEGIN PGP PUBLIC KEY BLOCK' "$KEY"; then
+          if [ -f "$KEY" ] && grep -q '^-----BEGIN PGP PUBLIC KEY BLOCK-----' "$KEY"; then
             echo "Verifying signature of tag $TAG against the committed release key..."
             gpg --quiet --import "$KEY"
             git fetch --force origin "refs/tags/${TAG}:refs/tags/${TAG}"

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           set -euo pipefail
           KEY=.github/release-signing-key.asc
-          if [ -f "$KEY" ] && grep -q 'BEGIN PGP PUBLIC KEY BLOCK' "$KEY"; then
+          if [ -f "$KEY" ] && grep -q '^-----BEGIN PGP PUBLIC KEY BLOCK-----' "$KEY"; then
             echo "Verifying signature of tag $TAG against the committed release key..."
             gpg --quiet --import "$KEY"
             git fetch --force origin "refs/tags/${TAG}:refs/tags/${TAG}"


### PR DESCRIPTION
The v3.4.3 release builds all failed at the `Verify release tag signature` step. Root cause: the guard `grep -q 'BEGIN PGP PUBLIC KEY BLOCK'` matched the **placeholder** `release-signing-key.asc`, because the placeholder's own instructions contained that phrase. That drove the step into the enforcing branch, `gpg --import` on the placeholder failed ("no valid OpenPGP data found"), and `set -e` failed the job — so the "inert until a key is committed" scaffolding wasn't inert.

Fix: anchor the guard to the real armored header (`^-----BEGIN PGP PUBLIC KEY BLOCK-----`, which only a genuine key's first line matches) in both release workflows, and reword the placeholder so it can't self-match. Verify step is now correctly skip-with-warning until a real key is dropped in.

Merging this, then re-pointing `v3.4.3` to the fixed commit and re-running the release builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196v7HCcvq3AdutY8W2Aup1

---
_Generated by [Claude Code](https://claude.ai/code/session_0196v7HCcvq3AdutY8W2Aup1)_